### PR TITLE
Replace with_address with with_current_contract for cleaner API usage

### DIFF
--- a/contracts/crossmint-contract-factory/src/lib.rs
+++ b/contracts/crossmint-contract-factory/src/lib.rs
@@ -35,7 +35,7 @@ impl CrossmintContractFactory {
         // by the same `CrossmintContractFactory` contract address.
         let deployed_address = env
             .deployer()
-            .with_address(env.current_contract_address(), salt)
+            .with_current_contract(salt)
             .deploy_v2(wasm_hash, constructor_args);
 
         deployed_address
@@ -43,7 +43,7 @@ impl CrossmintContractFactory {
 
     pub fn get_deployed_address(env: Env, salt: BytesN<32>) -> Address {
         env.deployer()
-            .with_address(env.current_contract_address(), salt)
+            .with_current_contract(salt)
             .deployed_address()
     }
 }


### PR DESCRIPTION

# Replace with_address with with_current_contract for cleaner API usage

## Summary

This PR replaces `with_address(env.current_contract_address(), salt)` with `with_current_contract(salt)` in the CrossmintContractFactory contract. The change affects two functions:

- `deploy()` - Used for actual contract deployment
- `get_deployed_address()` - Used for address prediction

This change uses the more direct and cleaner Soroban SDK API method while maintaining the same functionality. The `with_current_contract` method is specifically designed for this use case where you want to deploy contracts using the current contract's address as the deployer.

## Review & Testing Checklist for Human

- [ ] **Verify API equivalence**: Confirm that `with_current_contract(salt)` produces identical results to `with_address(env.current_contract_address(), salt)` by checking Soroban SDK documentation and testing both methods side-by-side
- [ ] **Test actual contract deployment**: Deploy a real contract using the updated factory and verify it works correctly (not just address prediction)
- [ ] **Verify address consistency**: Ensure the same salt values produce the same contract addresses before and after this change

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "CrossmintContractFactory"
        LibRS["contracts/crossmint-contract-factory/src/lib.rs"]:::major-edit
        TestRS["contracts/crossmint-contract-factory/src/test.rs"]:::context
    end
    
    subgraph "Core Changes"
        Deploy["deploy() function<br/>Line 38: with_current_contract(salt)"]:::major-edit
        GetAddr["get_deployed_address() function<br/>Line 46: with_current_contract(salt)"]:::major-edit
    end
    
    subgraph "Soroban SDK"
        Deployer["env.deployer()"]:::context
        WithCurrent["with_current_contract(salt)"]:::major-edit
    end
    
    LibRS --> Deploy
    LibRS --> GetAddr
    Deploy --> Deployer
    GetAddr --> Deployer
    Deployer --> WithCurrent
    
    TestRS --> Deploy
    TestRS --> GetAddr
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- All existing tests (15 tests) pass, confirming the change doesn't break existing functionality
- The change reduces code verbosity by removing the need to explicitly call `env.current_contract_address()`
- Both functions are critical for the contract factory's core functionality: predicting and deploying contracts
- Session requested by @alberto-crossmint
- Link to Devin run: https://app.devin.ai/sessions/17e86d731ff64628abd171d7f776405d
