### PR TITLE
refactor: remove require_auth macro and implement inline authorization checks

### DIFF
--- a/contracts/smart-wallet/src/auth/mod.rs
+++ b/contracts/smart-wallet/src/auth/mod.rs
@@ -54,6 +54,5 @@
 pub mod permissions;
 pub mod policy;
 pub mod proof;
-pub mod require_auth;
 pub mod signer;
 pub mod signers;

--- a/contracts/smart-wallet/src/auth/require_auth.rs
+++ b/contracts/smart-wallet/src/auth/require_auth.rs
@@ -1,8 +1,0 @@
-#[macro_export]
-macro_rules! require_auth {
-    ($env:expr) => {
-        if Self::is_initialized($env) {
-            $env.current_contract_address().require_auth();
-        }
-    };
-}

--- a/contracts/smart-wallet/src/wallet.rs
+++ b/contracts/smart-wallet/src/wallet.rs
@@ -4,7 +4,6 @@ use crate::auth::signer::{Signer, SignerKey};
 use crate::auth::signers::SignatureVerifier as _;
 use crate::error::Error;
 use crate::interface::SmartWalletInterface;
-use crate::require_auth;
 use initializable::{only_not_initialized, Initializable};
 use soroban_sdk::{
     auth::{Context, CustomAccountInterface},
@@ -82,7 +81,9 @@ impl SmartWalletInterface for SmartWallet {
     }
 
     fn add_signer(env: &Env, signer: Signer) -> Result<(), Error> {
-        require_auth!(env);
+        if Self::is_initialized(env) {
+            env.current_contract_address().require_auth();
+        }
         Storage::default().store::<SignerKey, Signer>(
             env,
             &signer.clone().into(),
@@ -92,7 +93,9 @@ impl SmartWalletInterface for SmartWallet {
     }
 
     fn update_signer(env: &Env, signer: Signer) -> Result<(), Error> {
-        require_auth!(env);
+        if Self::is_initialized(env) {
+            env.current_contract_address().require_auth();
+        }
         Storage::default().update::<SignerKey, Signer>(
             env,
             &signer.clone().into(),
@@ -102,7 +105,9 @@ impl SmartWalletInterface for SmartWallet {
     }
 
     fn revoke_signer(env: &Env, signer_key: SignerKey) -> Result<(), Error> {
-        require_auth!(env);
+        if Self::is_initialized(env) {
+            env.current_contract_address().require_auth();
+        }
         Storage::default().delete::<SignerKey>(env, &signer_key)?;
         Ok(())
     }


### PR DESCRIPTION

# refactor: remove require_auth macro and implement inline authorization checks

## Summary

This PR removes the `require_auth!` macro anti-pattern and replaces all usages with explicit inline authorization checks. The macro was hiding important authorization logic and making debugging difficult.

**Key changes:**
- Deleted `contracts/smart-wallet/src/auth/require_auth.rs` (macro definition)
- Removed module reference from `contracts/smart-wallet/src/auth/mod.rs`
- Removed import statement from `contracts/smart-wallet/src/wallet.rs`
- Replaced 3 macro usages with inline checks: `if Self::is_initialized(env) { env.current_contract_address().require_auth(); }`

The functionality remains identical, but the authorization flow is now explicit and debuggable.

## Review & Testing Checklist for Human

This is a **high-risk** change affecting security-critical authorization logic. Please verify:

- [ ] **Verify functional equivalence**: Compare the inline authorization checks against the original macro definition to ensure they are exactly equivalent
- [ ] **Test authorization scenarios**: Manually test that wallet authorization still works correctly for all signer operations (add, update, revoke)
- [ ] **Run full test suite**: Execute all tests to ensure no regressions were introduced
- [ ] **Search for missed references**: Double-check that no `require_auth!` macro usages were missed in the codebase
- [ ] **Test edge cases**: Verify authorization behavior when wallet is not initialized vs initialized

**Recommended test plan**: Deploy the contract locally, test adding/updating/revoking signers with proper authorization, and verify that unauthorized attempts are still rejected.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Smart Wallet Authorization Flow"
        A["contracts/smart-wallet/src/wallet.rs<br/>SmartWalletInterface"]:::major-edit
        B["contracts/smart-wallet/src/auth/require_auth.rs<br/>require_auth! macro"]:::deleted
        C["contracts/smart-wallet/src/auth/mod.rs<br/>Module declarations"]:::minor-edit
        D["initializable crate<br/>is_initialized()"]:::context
        E["soroban_sdk<br/>require_auth()"]:::context
    end
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
        L4[Deleted]:::deleted
    end
    
    A -->|"used to call"| B
    A -->|"now calls directly"| D
    A -->|"now calls directly"| E
    C -->|"removed reference"| B
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
    classDef deleted fill:#FFB6C1
```

### Notes

- The macro simply wrapped the same conditional authorization check that is now inline
- All environment parameters were consistently named `env` across the codebase
- The `is_initialized` method is available through the `Initializable` trait
- Compilation passes with `cargo check` but full testing is recommended
- This change improves code maintainability and debugging capabilities

**Link to Devin run**: https://app.devin.ai/sessions/8a6e106acbb948949251af81bccc9407  
**Requested by**: Alberto García (@alberto-crossmint)
