### PR TITLE
Improve signer validation in smart-wallet constructor

### DIFF
--- a/contracts/smart-wallet/src/tests/auth.rs
+++ b/contracts/smart-wallet/src/tests/auth.rs
@@ -105,3 +105,23 @@ fn test_deploy_without_sufficient_permissions() {
     let test_signer = Ed25519TestSigner::generate(SignerRole::Standard);
     env.register(SmartWallet, (vec![&env, test_signer.into_signer(&env)],));
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #21)")]
+fn test_constructor_duplicate_signers() {
+    let env = setup();
+    let test_signer = Ed25519TestSigner::generate(SignerRole::Admin);
+    let signer1 = test_signer.into_signer(&env);
+    let signer2 = test_signer.into_signer(&env); // Same signer key, different instance
+    env.register(SmartWallet, (vec![&env, signer1, signer2],));
+}
+
+#[test]
+fn test_constructor_different_signers_success() {
+    let env = setup();
+    let test_signer1 = Ed25519TestSigner::generate(SignerRole::Admin);
+    let test_signer2 = Ed25519TestSigner::generate(SignerRole::Standard);
+    let signer1 = test_signer1.into_signer(&env);
+    let signer2 = test_signer2.into_signer(&env);
+    env.register(SmartWallet, (vec![&env, signer1, signer2],));
+}

--- a/contracts/smart-wallet/src/wallet.rs
+++ b/contracts/smart-wallet/src/wallet.rs
@@ -66,6 +66,15 @@ impl SmartWalletInterface for SmartWallet {
             panic_with_error!(env, Error::InsufficientPermissionsOnCreation);
         }
 
+        let mut seen_signer_keys = Vec::new(&env);
+        for signer in signers.iter() {
+            let signer_key: SignerKey = signer.clone().into();
+            if seen_signer_keys.contains(&signer_key) {
+                panic_with_error!(env, Error::SignerAlreadyExists);
+            }
+            seen_signer_keys.push_back(signer_key);
+        }
+
         signers.iter().for_each(|signer| {
             // If it's a restricted signer, we check that the policies are valid.
             if let SignerRole::Restricted(policies) = signer.role() {


### PR DESCRIPTION

# Improve signer validation in smart-wallet constructor

## Summary

This PR adds duplicate signer detection to the smart-wallet contract constructor to prevent the same SignerKey from being added multiple times during wallet initialization. The validation occurs early in the constructor, before policy validation, and uses the existing `Error::SignerAlreadyExists` error code.

**Key changes:**
- Added duplicate detection logic that collects SignerKeys and checks for duplicates using `Vec::contains()`
- Constructor now panics with `Error::SignerAlreadyExists` when duplicate signers are found
- Added comprehensive tests covering both duplicate detection and normal operation
- Maintains backward compatibility with existing functionality

## Review & Testing Checklist for Human

- [ ] **Verify duplicate detection logic**: Test the algorithm with various signer combinations to ensure it correctly identifies duplicates using the `Signer` -> `SignerKey` conversion
- [ ] **Performance validation**: Test with realistic signer counts (5-20 signers) to ensure the O(n²) algorithm doesn't cause performance issues
- [ ] **Integration testing**: Verify the new validation works correctly with existing admin signer checks and policy validation
- [ ] **Edge case testing**: Test with empty signer lists, single signers, and mixed signer roles to ensure robustness

**Recommended test plan:**
1. Create smart wallet with duplicate Ed25519 signers - should fail with `SignerAlreadyExists`
2. Create smart wallet with different signers - should succeed normally
3. Test with various signer counts (1, 5, 10+ signers) to verify performance
4. Verify existing functionality still works (admin requirements, policy validation)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    constructor["__constructor()<br/>wallet.rs"]:::major-edit
    signerCheck["Admin signer check<br/>(existing)"]:::context
    duplicateCheck["Duplicate signer detection<br/>(new validation)"]:::major-edit
    policyCheck["Policy validation<br/>(existing)"]:::context
    addSigner["add_signer calls<br/>(existing)"]:::context
    tests["auth.rs tests"]:::major-edit
    
    constructor --> signerCheck
    constructor --> duplicateCheck
    constructor --> policyCheck
    constructor --> addSigner
    
    tests --> |validates| duplicateCheck
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes


- The duplicate detection uses `Vec::contains()` which results in O(n²) complexity, but should be acceptable for typical signer counts
- The validation relies on the `Into<SignerKey>` trait implementation for `Signer` to properly identify duplicates
- Error code `SignerAlreadyExists` (21) was already defined and is reused for consistency
- All existing tests continue to pass, indicating no regressions

**Link to Devin run:** https://app.devin.ai/sessions/2cc078aaea9b4366bacf11ac3bdc446b  
**Requested by:** Alberto García (@alberto-crossmint)
