### PR TITLE
docs: specify callback failure policy for plugins and policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ The project maintains 80%+ test coverage with comprehensive integration tests.
 3. Add to `SignerPolicy` enum
 4. Update policy validation logic
 
+### Callback Failure Policy
+
+See the Smart Account contract documentation for the authoritative policy covering plugin and policy callbacks:
+- contracts/smart-account/README.md#callback-failure-policy
 See the [Smart Account Architecture Documentation](contracts/smart-account/README.md) for detailed extension guides.
 
 ## 🌐 Network Support

--- a/contracts/smart-account/src/auth/permissions.rs
+++ b/contracts/smart-account/src/auth/permissions.rs
@@ -8,10 +8,16 @@ use crate::{
     error::Error,
 };
 
+/// Common trait for checking authorization for a given set of contexts.
+/// Standard-role signers must satisfy all attached policies.
 pub trait AuthorizationCheck {
     fn is_authorized(&self, env: &Env, context: &Vec<Context>) -> bool;
 }
 
+/// Policy lifecycle callbacks for attaching/removing policies to signers.
+/// Failure policy:
+/// - on_add: errors bubble to the caller and block signer addition/update. (important-comment)
+/// - on_revoke: defined for cleanup; not currently invoked by SmartAccount.
 pub trait PolicyCallback {
     fn on_add(&self, env: &Env) -> Result<(), Error>;
     fn on_revoke(&self, env: &Env) -> Result<(), Error>;
@@ -92,5 +98,3 @@ impl AuthorizationCheck for SignerRole {
         }
     }
 }
-
-//

--- a/contracts/smart-account/src/auth/policy/interface.rs
+++ b/contracts/smart-account/src/auth/policy/interface.rs
@@ -1,8 +1,16 @@
 use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
 
 #[contractclient(name = "SmartAccountPolicyClient")]
+/// External policy interface for delegated authorization and lifecycle callbacks.
+/// Failure policy:
+/// - on_add: errors bubble to the caller and block signer addition/update.
+/// - on_revoke: intended for cleanup on signer revocation; currently not invoked by SmartAccount.
+/// - is_authorized: implementors should return false to deny; avoid panics to prevent unintended reverts.
 pub trait SmartAccountPolicy {
+    /// Called when a policy is added to a signer. Errors block the outer operation.
     fn on_add(env: &Env, source: Address);
+    /// Called when a policy is removed from a signer. Not currently invoked by SmartAccount.
     fn on_revoke(env: &Env, source: Address);
+    /// Returns true if the policy authorizes the provided contexts; false denies.
     fn is_authorized(env: &Env, source: Address, contexts: Vec<Context>) -> bool;
 }

--- a/contracts/smart-account/src/plugin.rs
+++ b/contracts/smart-account/src/plugin.rs
@@ -1,12 +1,16 @@
 use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
 
 #[contractclient(name = "SmartAccountPluginClient")]
-/// Plugin lifecycle interface for Smart Account extensions.
+/// Plugin lifecycle interface for Smart Account extensions. (important-comment)
+/// Failure policy:
+/// - on_install: any error reverts installation with Error::PluginInitializationFailed.
+/// - on_uninstall: errors do not revert; a PluginUninstallFailedEvent is emitted and uninstall continues.
+/// - on_auth: invoked directly after successful authorization; a panic in the plugin will revert __check_auth.
 pub trait SmartAccountPlugin {
-    /// Called after a plugin is installed.
+    /// Called after a plugin is installed. (important-comment)
     fn on_install(env: &Env, source: Address);
-    /// Called before a plugin is fully uninstalled. Failures are recorded via uninstall_failed event.
+    /// Called before a plugin is fully uninstalled. Failures are recorded via uninstall_failed event and uninstall proceeds. (important-comment)
     fn on_uninstall(env: &Env, source: Address);
-    /// Called after successful authorization to observe or react to auth contexts.
+    /// Called after successful authorization to observe or react to auth contexts. Panics will revert __check_auth. (important-comment)
     fn on_auth(env: &Env, source: Address, contexts: Vec<Context>);
 }


### PR DESCRIPTION
# docs: specify callback failure policy for plugins and policies

## Summary

Added comprehensive documentation specifying when plugin and policy callbacks fail (revert operations) versus continue (emit events). This addresses the need for clear failure handling policies in the Smart Account contract's extensible plugin and policy system.

**Key Documentation Added:**
- **Plugin callbacks**: on_install (reverts on failure), on_uninstall (emits event and continues), on_auth (panic reverts __check_auth)
- **Policy callbacks**: on_add (errors bubble and block operations), on_revoke (defined but not currently invoked), is_authorized (false denies, should avoid panics)
- **Comprehensive README section** with behavior matrix and builder guidance for both human users and AI agents
- **Cross-references** between top-level and contract-specific READMEs

## Review & Testing Checklist for Human

- [ ] **Verify documented failure policies match actual code behavior** - Check that plugin on_install really reverts with Error::PluginInitializationFailed, on_uninstall emits PluginUninstallFailedEvent and continues, and on_auth panics revert __check_auth
- [ ] **Confirm policy callback behaviors** - Validate that on_add errors bubble to block signer operations, and is_authorized false results deny authorization as documented
- [ ] **Test callback failure scenarios** - Create test plugins/policies that fail in each callback and verify the documented behavior (events emitted vs operations reverted)
- [ ] **Review completeness** - Ensure all callback scenarios are covered and no edge cases are missing from the documentation

## Test plan

Verification that cargo fmt/build/clippy/test all pass (completed locally). Human reviewer should create simple test plugins/policies that intentionally fail in each callback type and verify the documented failure behaviors match reality.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Smart Account Contract"
        plugin_rs["contracts/smart-account/src/plugin.rs<br/>SmartAccountPlugin trait"]:::major-edit
        interface_rs["contracts/smart-account/src/auth/policy/interface.rs<br/>SmartAccountPolicy trait"]:::major-edit
        permissions_rs["contracts/smart-account/src/auth/permissions.rs<br/>PolicyCallback + AuthorizationCheck traits"]:::major-edit
        account_rs["contracts/smart-account/src/account.rs<br/>Implementation logic"]:::context
        events_rs["contracts/smart-account/src/events.rs<br/>Event definitions"]:::context
    end
    
    subgraph "Documentation"
        contract_readme["contracts/smart-account/README.md<br/>Callback Failure Policy section"]:::major-edit
        toplevel_readme["README.md<br/>Cross-reference link"]:::minor-edit
    end
    
    plugin_rs -.-> account_rs
    interface_rs -.-> account_rs
    permissions_rs -.-> account_rs
    account_rs -.-> events_rs
    contract_readme --> plugin_rs
    contract_readme --> interface_rs
    contract_readme --> permissions_rs
    toplevel_readme --> contract_readme
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes

- **Documentation-only changes** - No runtime behavior modifications, only documenting existing policies
- **AI agent compatibility** - Documentation includes guidance for both human users and AI agents per Crossmint standards
- **Cross-references** - Added navigation between top-level and contract-specific documentation
- **Session details** - Requested by Alberto García (@alberto-crossmint), session: https://app.devin.ai/sessions/e0be7f81c0ac4d03b1f0fd690b2625a5