### PR TITLE
Extract reusable smart account interfaces (Plugin, Policy) into new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 name = "deny-list-policy"
 version = "0.0.0"
 dependencies = [
+ "smart-account-interfaces",
  "soroban-sdk",
 ]
 
@@ -1795,10 +1796,18 @@ dependencies = [
  "passkey",
  "rand 0.7.3",
  "serde_json",
+ "smart-account-interfaces",
  "soroban-sdk",
  "stellar-strkey 0.0.13",
  "storage",
  "upgradeable",
+]
+
+[[package]]
+name = "smart-account-interfaces"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "contracts/*",
+  "crates/*",
 ]
 
 [workspace.package]
@@ -15,7 +16,7 @@ initializable = { path = "contracts/initializable" }
 storage = { path = "contracts/storage" }
 upgradeable = { path = "contracts/upgradeable" }
 sac-token-policy = { path = "contracts/upgradeable" }
-
+smart-account-interfaces = { path = "crates/smart-account-interfaces" }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/deny-list-policy/Cargo.toml
+++ b/contracts/deny-list-policy/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+smart-account-interfaces = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/deny-list-policy/src/lib.rs
+++ b/contracts/deny-list-policy/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use smart_account_interfaces::SmartAccountPolicy;
 use soroban_sdk::{auth::Context, contract, contractimpl, symbol_short, Address, Env, Symbol, Vec};
 
 const CONTRACTS_SYMBOL: Symbol = symbol_short!("CONTRACTS");
@@ -13,12 +14,6 @@ impl DenyListPolicy {
             .instance()
             .set(&CONTRACTS_SYMBOL, &denied_contracts);
     }
-}
-
-pub trait SmartAccountPolicy {
-    fn on_add(env: &Env, source: Address);
-    fn on_revoke(env: &Env, source: Address);
-    fn is_authorized(env: &Env, source: Address, contexts: Vec<Context>) -> bool;
 }
 
 #[contractimpl]

--- a/contracts/smart-account/Cargo.toml
+++ b/contracts/smart-account/Cargo.toml
@@ -14,6 +14,7 @@ soroban-sdk = { workspace = true }
 initializable = { workspace = true }
 storage = { workspace = true }
 upgradeable = { workspace = true }
+smart-account-interfaces = { workspace = true }
 
 
 [dev-dependencies]

--- a/contracts/smart-account/src/auth/policy/interface.rs
+++ b/contracts/smart-account/src/auth/policy/interface.rs
@@ -1,8 +1,1 @@
-use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
-
-#[contractclient(name = "SmartAccountPolicyClient")]
-pub trait SmartAccountPolicy {
-    fn on_add(env: &Env, source: Address);
-    fn on_revoke(env: &Env, source: Address);
-    fn is_authorized(env: &Env, source: Address, contexts: Vec<Context>) -> bool;
-}
+pub use smart_account_interfaces::{SmartAccountPolicy, SmartAccountPolicyClient};

--- a/contracts/smart-account/src/plugin.rs
+++ b/contracts/smart-account/src/plugin.rs
@@ -1,12 +1,1 @@
-use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
-
-#[contractclient(name = "SmartAccountPluginClient")]
-/// Plugin lifecycle interface for Smart Account extensions.
-pub trait SmartAccountPlugin {
-    /// Called after a plugin is installed.
-    fn on_install(env: &Env, source: Address);
-    /// Called before a plugin is fully uninstalled. Failures are recorded via uninstall_failed event.
-    fn on_uninstall(env: &Env, source: Address);
-    /// Called after successful authorization to observe or react to auth contexts.
-    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>);
-}
+pub use smart_account_interfaces::{SmartAccountPlugin, SmartAccountPluginClient};

--- a/crates/smart-account-interfaces/Cargo.toml
+++ b/crates/smart-account-interfaces/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "smart-account-interfaces"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/Crossmint/stellar-smart-account"
+description = "Reusable interfaces (traits) for Stellar Smart Account plugins and policies."
+
+[lib]
+name = "smart_account_interfaces"
+path = "src/lib.rs"
+
+[dependencies]
+soroban-sdk = "22.0.0"

--- a/crates/smart-account-interfaces/src/lib.rs
+++ b/crates/smart-account-interfaces/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod plugin;
+pub mod policy;
+
+pub use plugin::{SmartAccountPlugin, SmartAccountPluginClient};
+pub use policy::{SmartAccountPolicy, SmartAccountPolicyClient};

--- a/crates/smart-account-interfaces/src/plugin.rs
+++ b/crates/smart-account-interfaces/src/plugin.rs
@@ -1,0 +1,8 @@
+use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
+
+#[contractclient(name = "SmartAccountPluginClient")]
+pub trait SmartAccountPlugin {
+    fn on_install(env: &Env, source: Address);
+    fn on_uninstall(env: &Env, source: Address);
+    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>);
+}

--- a/crates/smart-account-interfaces/src/policy.rs
+++ b/crates/smart-account-interfaces/src/policy.rs
@@ -1,0 +1,8 @@
+use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
+
+#[contractclient(name = "SmartAccountPolicyClient")]
+pub trait SmartAccountPolicy {
+    fn on_add(env: &Env, source: Address);
+    fn on_revoke(env: &Env, source: Address);
+    fn is_authorized(env: &Env, source: Address, contexts: Vec<Context>) -> bool;
+}


### PR DESCRIPTION
# Extract reusable smart account interfaces (Plugin, Policy) into new crate

## Summary

This PR extracts the `SmartAccountPlugin` and `SmartAccountPolicy` traits into a new reusable crate `crates/smart-account-interfaces` to increase reusability for third-party plugin and policy implementers. Previously, these traits were defined within the smart-account contract, requiring external implementers to depend on the entire smart account contract. Now they can depend on just the lightweight interfaces crate.

**Key Changes:**
- **New crate:** `crates/smart-account-interfaces` containing `SmartAccountPlugin` and `SmartAccountPolicy` traits with `#[contractclient]` annotations
- **Refactored imports:** `contracts/smart-account` now re-exports traits from the shared crate
- **Eliminated duplication:** `contracts/deny-list-policy` no longer defines its own `SmartAccountPolicy` trait, instead importing from the shared crate
- **Workspace updates:** Added `crates/*` to workspace members and added the new crate as a workspace dependency

The extraction keeps `SmartAccountInterface` internal to avoid coupling external consumers to implementation-specific types like `Signer`, `SignerKey`, and `Error`.

## Review & Testing Checklist for Human

- [ ] **Verify deny-list-policy behavior unchanged** - Deploy and test a deny-list policy contract to ensure it behaves identically to before (most critical change)
- [ ] **Confirm TypeScript bindings generation works** - Run `stellar contract bindings typescript` to ensure WASM-to-TS codegen is unaffected
- [ ] **Test plugin/policy import paths** - Verify external consumers can still import `SmartAccountPluginClient` and `SmartAccountPolicyClient` from expected paths
- [ ] **End-to-end smart account operations** - Test complete flows including plugin installation/uninstallation and policy authorization to catch any subtle behavioral changes

**Recommended test plan:** Deploy a smart account with plugins and policies on testnet, then run the examples in `examples/smart-account-operations.ts` to verify all operations work correctly.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    WS["Cargo.toml<br/>(workspace)"]:::minor-edit
    SAI["crates/smart-account-interfaces/"]:::major-edit
    SAI_LIB["src/lib.rs"]:::major-edit
    SAI_PLUGIN["src/plugin.rs"]:::major-edit  
    SAI_POLICY["src/policy.rs"]:::major-edit
    
    SA["contracts/smart-account/"]:::minor-edit
    SA_PLUGIN["src/plugin.rs"]:::minor-edit
    SA_POLICY["src/auth/policy/interface.rs"]:::minor-edit
    SA_CARGO["Cargo.toml"]:::minor-edit
    
    DLP["contracts/deny-list-policy/"]:::major-edit
    DLP_LIB["src/lib.rs"]:::major-edit
    DLP_CARGO["Cargo.toml"]:::minor-edit
    
    WS -->|"adds crates/*"| SAI
    SAI --> SAI_LIB
    SAI --> SAI_PLUGIN
    SAI --> SAI_POLICY
    
    SA --> SA_PLUGIN
    SA --> SA_POLICY  
    SA --> SA_CARGO
    SA_CARGO -->|"depends on"| SAI
    SA_PLUGIN -->|"re-exports from"| SAI
    SA_POLICY -->|"re-exports from"| SAI
    
    DLP --> DLP_LIB
    DLP --> DLP_CARGO
    DLP_CARGO -->|"depends on"| SAI
    DLP_LIB -->|"imports trait from"| SAI
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- All local checks pass: `cargo fmt --check`, `cargo clippy`, and `cargo test` (66 tests across all crates)
- The `#[contractclient]` macro annotations are preserved in the new crate to maintain client generation functionality
- This change enables third-party developers to implement plugins and policies without depending on the full smart-account contract
- Future work could include extracting shared auth types (SignerRole, SignerPolicy) if external implementers need direct access to them

**Session Info:** Requested by Alberto García (@alberto-crossmint)  
**Link to Devin run:** https://app.devin.ai/sessions/9dc12923acc74e238ad60e8a3af5bf02