### PR TITLE
Release: add optimized WASM artifacts and hashes to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,17 +112,36 @@ jobs:
         pnpm run build
         cd ../..
 
+    - name: Optimize WASM contracts
+      run: |
+        mkdir -p target/wasm32v1-none/release/optimized
+        stellar contract optimize \
+          --wasm target/wasm32v1-none/release/smart_account.wasm \
+          --wasm-out target/wasm32v1-none/release/optimized/smart_account.optimized.wasm
+        stellar contract optimize \
+          --wasm target/wasm32v1-none/release/contract_factory.wasm \
+          --wasm-out target/wasm32v1-none/release/optimized/contract_factory.optimized.wasm
+
     - name: Calculate WASM hashes and create release tarfile
       run: |
         # Create release directory
         mkdir -p release-artifacts
         
-        # Copy WASM files
+        # Copy unoptimized WASM files
         cp target/wasm32v1-none/release/*.wasm release-artifacts/
         
-        # Generate hash file
+        # Copy optimized WASM files (if present)
+        mkdir -p release-artifacts/optimized
+        if [ -d "target/wasm32v1-none/release/optimized" ]; then
+          cp target/wasm32v1-none/release/optimized/*.wasm release-artifacts/optimized/ || true
+        fi
+        
+        # Generate hash files
         cd release-artifacts
         sha256sum *.wasm > wasm-hashes.txt
+        if [ -d "optimized" ] && ls optimized/*.wasm >/dev/null 2>&1; then
+          (cd optimized && sha256sum *.wasm > ../optimized-wasm-hashes.txt)
+        fi
         cd ..
         
         # Copy TypeScript packages
@@ -133,7 +152,7 @@ jobs:
         cp packages/smart_account/package.json release-artifacts/smart_account_types/
         cp packages/factory/package.json release-artifacts/factory_types/
         
-        # Create tarfile
+        # Create tarfile including both optimized and unoptimized artifacts
         tar -czf stellar-smart-account-release-${{ github.event.release.tag_name }}.tar.gz -C release-artifacts .
         
         # List contents for verification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,16 @@ jobs:
 
     - name: Optimize WASM contracts
       run: |
-        mkdir -p target/wasm32v1-none/release/optimized
-        stellar contract optimize \
-          --wasm target/wasm32v1-none/release/smart_account.wasm \
-          --wasm-out target/wasm32v1-none/release/optimized/smart_account.optimized.wasm
-        stellar contract optimize \
-          --wasm target/wasm32v1-none/release/contract_factory.wasm \
-          --wasm-out target/wasm32v1-none/release/optimized/contract_factory.optimized.wasm
+        set -euo pipefail
+        OUT_DIR="target/wasm32v1-none/release/optimized"
+        mkdir -p "$OUT_DIR"
+        for wasm in target/wasm32v1-none/release/*.wasm; do
+          [ -e "$wasm" ] || continue
+          base="$(basename "$wasm" .wasm)"
+          stellar contract optimize \
+            --wasm "$wasm" \
+            --wasm-out "$OUT_DIR/${base}.optimized.wasm"
+        done
 
     - name: Calculate WASM hashes and create release tarfile
       run: |


### PR DESCRIPTION
# Release: add optimized WASM artifacts and hashes to release

## Summary
Adds `stellar contract optimize` step to the release GitHub Action workflow to generate optimized versions of all built WASM contracts. The optimized WASMs and their SHA256 hashes are now included in the release tarball alongside the original unoptimized versions.

**Changes:**
- New "Optimize WASM contracts" step runs after TypeScript build that loops through all built .wasm files
- Optimized WASMs stored in `release-artifacts/optimized/` with `.optimized.wasm` suffix  
- Generates `optimized-wasm-hashes.txt` containing SHA256 hashes of optimized contracts
- Release tarball now includes both original and optimized artifacts with their respective hash files

## Review & Testing Checklist for Human
- [ ] **Verify `stellar contract optimize` command syntax and availability** - I assumed `--wasm` and `--wasm-out` flags but haven't tested this with the CLI version used (v23.0.0)
- [ ] **Test optimized contracts are functionally equivalent to unoptimized versions** - Deploy both to testnet and verify identical behavior 
- [ ] **Test complete release workflow end-to-end** - Create a test release to verify new steps execute successfully and tarball contents are correct
- [ ] **Verify error handling** - Test what happens if `stellar contract optimize` fails for any contract

### Recommended Test Plan
1. Run the optimize step locally: `stellar contract optimize --wasm target/wasm32v1-none/release/smart_account.wasm --wasm-out test.optimized.wasm`
2. Create a test release and verify tarball contains both `wasm-hashes.txt` and `optimized-wasm-hashes.txt` 
3. Compare file sizes (optimized should be smaller) and deploy both versions to verify functional equivalence

### Notes
- Uses dynamic discovery of all built WASMs rather than hardcoding contract names
- Includes defensive scripting (`set -euo pipefail`, file existence checks) to handle edge cases
- Maintains backward compatibility - original WASMs and hashes still included

**Link to Devin run:** https://app.devin.ai/sessions/1e4a68a8224c447aa38788678b35cf92  
**Requested by:** Alberto García (@alberto-crossmint)