### PR TITLE
Account: Expose get signer operations

### DIFF
--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -164,6 +164,16 @@ impl SmartAccountInterface for SmartAccount {
         Ok(())
     }
 
+    fn get_signer(env: &Env, signer_key: SignerKey) -> Result<Signer, Error> {
+        Storage::persistent()
+            .get::<SignerKey, Signer>(env, &signer_key)
+            .ok_or(Error::SignerNotFound)
+    }
+
+    fn has_signer(env: &Env, signer_key: SignerKey) -> Result<bool, Error> {
+        Ok(Storage::persistent().has::<SignerKey>(env, &signer_key))
+    }
+
     fn install_plugin(env: &Env, plugin: Address) -> Result<(), Error> {
         Self::require_auth_if_initialized(env);
 

--- a/contracts/smart-account/src/interface.rs
+++ b/contracts/smart-account/src/interface.rs
@@ -15,6 +15,10 @@ pub trait SmartAccountInterface {
     fn update_signer(env: &Env, signer: Signer) -> Result<(), Error>;
     /// Revokes a signer by key.
     fn revoke_signer(env: &Env, signer: SignerKey) -> Result<(), Error>;
+    /// Gets a signer by key.
+    fn get_signer(env: &Env, signer_key: SignerKey) -> Result<Signer, Error>;
+    /// Checks if a signer exists.
+    fn has_signer(env: &Env, signer_key: SignerKey) -> Result<bool, Error>;
     /// Installs a plugin and invokes its initialization hook.
     fn install_plugin(env: &Env, plugin: Address) -> Result<(), Error>;
     /// Uninstalls a plugin and invokes its uninstall hook. Emits uninstall_failed on hook error.

--- a/contracts/smart-account/src/tests/signer_management_test.rs
+++ b/contracts/smart-account/src/tests/signer_management_test.rs
@@ -187,9 +187,9 @@ fn test_has_signer_returns_true_when_signer_exists() {
     });
 
     assert!(admin_result.is_ok());
-    assert_eq!(admin_result.unwrap(), true);
+    assert!(admin_result.unwrap());
     assert!(standard_result.is_ok());
-    assert_eq!(standard_result.unwrap(), true);
+    assert!(standard_result.unwrap());
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn test_has_signer_returns_false_when_signer_does_not_exist() {
     });
 
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), false);
+    assert!(!result.unwrap());
 }
 
 #[test]


### PR DESCRIPTION
This is so a user can ask the account contract about whether it contains a given signer