### PR TITLE
fix(FIND-011): add extend_ttl after all persistent storage writes

### DIFF
--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -3,8 +3,9 @@ use crate::auth::permissions::PolicyCallback;
 use crate::auth::proof::SignatureProofs;
 use crate::config::{
     ADMIN_COUNT_KEY, CONTRACT_VERSION_KEY, CURRENT_CONTRACT_VERSION, INSTANCE_EXTEND_TO,
-    INSTANCE_TTL_THRESHOLD, PLUGINS_KEY, TOPIC_PLUGIN, TOPIC_SIGNER, VERB_ADDED, VERB_INSTALLED,
-    VERB_REVOKED, VERB_UNINSTALLED, VERB_UNINSTALL_FAILED, VERB_UPDATED,
+    INSTANCE_TTL_THRESHOLD, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD, PLUGINS_KEY,
+    TOPIC_PLUGIN, TOPIC_SIGNER, VERB_ADDED, VERB_INSTALLED, VERB_REVOKED, VERB_UNINSTALLED,
+    VERB_UNINSTALL_FAILED, VERB_UPDATED,
 };
 use crate::error::Error;
 use crate::events::{
@@ -162,6 +163,7 @@ impl SmartAccountInterface for SmartAccount {
         let key = signer.clone().into();
         let storage = Storage::persistent();
         storage.store::<SignerKey, Signer>(env, &key, &signer)?;
+        storage.extend_ttl(env, &key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_EXTEND_TO);
 
         // Handle role-specific initialization
         match signer.role() {
@@ -204,6 +206,7 @@ impl SmartAccountInterface for SmartAccount {
 
         // Update the signer in storage
         storage.update::<SignerKey, Signer>(env, &key, &signer)?;
+        storage.extend_ttl(env, &key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_EXTEND_TO);
         env.events().publish(
             (TOPIC_SIGNER, VERB_UPDATED),
             SignerUpdatedEvent::from(signer),
@@ -372,6 +375,11 @@ impl SmartAccount {
             .checked_sub(1)
             .ok_or(SmartAccountError::CannotDowngradeLastAdmin)?;
         storage.update::<Symbol, u32>(env, &ADMIN_COUNT_KEY, &new_count)?;
+        env.storage().persistent().extend_ttl(
+            &ADMIN_COUNT_KEY,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_EXTEND_TO,
+        );
         Ok(())
     }
 
@@ -385,6 +393,11 @@ impl SmartAccount {
             .checked_add(1)
             .ok_or(SmartAccountError::MaxSignersReached)?;
         storage.update::<Symbol, u32>(env, &ADMIN_COUNT_KEY, &new_count)?;
+        env.storage().persistent().extend_ttl(
+            &ADMIN_COUNT_KEY,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_EXTEND_TO,
+        );
         Ok(())
     }
 

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -3,7 +3,8 @@ use crate::auth::permissions::AuthorizationCheck;
 use crate::auth::proof::SignatureProofs;
 use crate::auth::signers::SignatureVerifier as _;
 use crate::config::{
-    PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD, PLUGINS_KEY, TOPIC_PLUGIN, VERB_AUTH_FAILED,
+    ADMIN_COUNT_KEY, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD, PLUGINS_KEY, TOPIC_PLUGIN,
+    VERB_AUTH_FAILED,
 };
 use crate::error::Error;
 use crate::events::PluginAuthFailedEvent;
@@ -54,6 +55,15 @@ impl Authorizer {
                 SignerRole::Admin => admin_signers.push_back(signer),
                 SignerRole::Standard(_, _) => standard_signers.push_back(signer),
             }
+        }
+
+        // Keep the admin count alive alongside signer entries
+        if env.storage().persistent().has(&ADMIN_COUNT_KEY) {
+            env.storage().persistent().extend_ttl(
+                &ADMIN_COUNT_KEY,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_EXTEND_TO,
+            );
         }
 
         for signer in admin_signers.iter() {

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -5,11 +5,23 @@ use soroban_sdk::{
 
 use crate::{
     auth::permissions::{AuthorizationCheck, PolicyCallback},
-    config::{PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD},
+    config::{DAY_IN_LEDGERS, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD},
 };
 use smart_account_interfaces::{
     SignerKey, SmartAccountError, SpendTrackerKey, SpendingTracker, TokenTransferPolicy,
 };
+
+/// Computes the TTL extend_to value for a spending tracker.
+/// Ensures the tracker stays live for at least one full spending window.
+fn tracker_extend_to(reset_window_secs: u64) -> u32 {
+    if reset_window_secs > 0 {
+        let secs_per_ledger = 86400 / DAY_IN_LEDGERS as u64;
+        let window_ledgers = (reset_window_secs / secs_per_ledger) as u32 + DAY_IN_LEDGERS;
+        window_ledgers.max(PERSISTENT_EXTEND_TO)
+    } else {
+        PERSISTENT_EXTEND_TO
+    }
+}
 
 impl AuthorizationCheck for TokenTransferPolicy {
     fn is_authorized(&self, env: &Env, signer_key: &SignerKey, contexts: &Vec<Context>) -> bool {
@@ -106,10 +118,11 @@ impl AuthorizationCheck for TokenTransferPolicy {
             // Update spending tracker
             tracker.spent = new_total;
             env.storage().persistent().set(&tracker_key, &tracker);
+
             env.storage().persistent().extend_ttl(
                 &tracker_key,
                 PERSISTENT_TTL_THRESHOLD,
-                PERSISTENT_EXTEND_TO,
+                tracker_extend_to(self.reset_window_secs),
             );
         }
 
@@ -136,7 +149,7 @@ impl PolicyCallback for TokenTransferPolicy {
             env.storage().persistent().extend_ttl(
                 &tracker_key,
                 PERSISTENT_TTL_THRESHOLD,
-                PERSISTENT_EXTEND_TO,
+                tracker_extend_to(self.reset_window_secs),
             );
         }
 

--- a/contracts/smart-account/src/migration/v1_to_v2.rs
+++ b/contracts/smart-account/src/migration/v1_to_v2.rs
@@ -12,6 +12,7 @@ use smart_account_interfaces::{
 use soroban_sdk::{contracttype, Env, Vec};
 
 use super::v1_types::{V1Signer, V1SignerKey, V1SignerPolicy, V1SignerRole};
+use crate::config::{PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
 
 /// Data required by the migration function.
 /// The caller must provide the list of v1 signer keys that need migration.
@@ -42,6 +43,11 @@ pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) {
         // Convert and write the new entry
         let (new_key, new_signer) = convert_signer(env, &old_key, &old_signer);
         env.storage().persistent().set(&new_key, &new_signer);
+        env.storage().persistent().extend_ttl(
+            &new_key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_EXTEND_TO,
+        );
     }
 }
 

--- a/contracts/storage/src/lib.rs
+++ b/contracts/storage/src/lib.rs
@@ -185,6 +185,25 @@ impl Storage {
         Ok(())
     }
 
+    pub fn extend_ttl<K: IntoVal<Env, Val>>(
+        &self,
+        env: &Env,
+        key: &K,
+        threshold: u32,
+        extend_to: u32,
+    ) {
+        match self.storage_type {
+            StorageType::Persistent => {
+                env.storage()
+                    .persistent()
+                    .extend_ttl(key, threshold, extend_to);
+            }
+            StorageType::Instance => {
+                // Instance storage TTL is managed at the instance level, not per-key
+            }
+        }
+    }
+
     pub fn has<K: IntoVal<Env, Val>>(&self, env: &Env, key: &K) -> bool {
         match self.storage_type {
             StorageType::Persistent => env.storage().persistent().has::<K>(key),


### PR DESCRIPTION
## Why
Multiple persistent storage entries are written without `extend_ttl`, causing their TTL to fall to `minPersistentTTL` instead of the intended 30-day window. This leads to unexpected restoration fees on every access to archived entries, and on pre-Protocol-23 networks, causes hard lockouts (signers not found, admin management blocked, spending counters silently reset to zero). Additionally, the spending tracker uses a fixed 30-day TTL regardless of the policy's `reset_window_secs`, so long spending windows (>30 days) cause the tracker to archive mid-window.

## Summary
- Adds `extend_ttl` after every persistent write on security-critical entries: migrated signers, admin count, signer store/update, and spending tracker
- Spending tracker TTL now scales with `reset_window_secs` via `max(PERSISTENT_EXTEND_TO, window_in_ledgers + 1_day_margin)`
- Adds `extend_ttl` method to the `Storage` wrapper crate

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] Verified by code review: all `persistent().set()` and `try_update()` calls on security-critical entries are now followed by `extend_ttl`
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/stellar-smart-account/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
