### PR TITLE
fix(FIND-002): enforce max plugin limit of 10 in install_plugin

### DIFF
--- a/contracts/smart-account-interfaces/src/error.rs
+++ b/contracts/smart-account-interfaces/src/error.rs
@@ -43,6 +43,7 @@ pub enum SmartAccountError {
     PluginAlreadyInstalled = 101,
     PluginInitializationFailed = 102,
     PluginOnAuthFailed = 103,
+    MaxPluginsReached = 104,
 
     MigrationVersionMismatch = 1101,
 

--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -3,8 +3,8 @@ use crate::auth::permissions::PolicyCallback;
 use crate::auth::proof::SignatureProofs;
 use crate::config::{
     ADMIN_COUNT_KEY, CONTRACT_VERSION_KEY, CURRENT_CONTRACT_VERSION, INSTANCE_EXTEND_TO,
-    INSTANCE_TTL_THRESHOLD, PLUGINS_KEY, TOPIC_PLUGIN, TOPIC_SIGNER, VERB_ADDED, VERB_INSTALLED,
-    VERB_REVOKED, VERB_UNINSTALLED, VERB_UNINSTALL_FAILED, VERB_UPDATED,
+    INSTANCE_TTL_THRESHOLD, MAX_PLUGINS, PLUGINS_KEY, TOPIC_PLUGIN, TOPIC_SIGNER, VERB_ADDED,
+    VERB_INSTALLED, VERB_REVOKED, VERB_UNINSTALLED, VERB_UNINSTALL_FAILED, VERB_UPDATED,
 };
 use crate::error::Error;
 use crate::events::{
@@ -257,6 +257,9 @@ impl SmartAccountInterface for SmartAccount {
             .unwrap();
         if existing_plugins.contains_key(plugin.clone()) {
             return Err(SmartAccountError::PluginAlreadyInstalled);
+        }
+        if existing_plugins.len() >= MAX_PLUGINS {
+            return Err(SmartAccountError::MaxPluginsReached);
         }
         existing_plugins.set(plugin.clone(), ());
         storage.update::<Symbol, Map<Address, ()>>(env, &PLUGINS_KEY, &existing_plugins)?;

--- a/contracts/smart-account/src/config.rs
+++ b/contracts/smart-account/src/config.rs
@@ -10,6 +10,7 @@ pub const INSTANCE_TTL_THRESHOLD: u32 = 7 * DAY_IN_LEDGERS;
 pub const INSTANCE_EXTEND_TO: u32 = 30 * DAY_IN_LEDGERS;
 pub const PERSISTENT_TTL_THRESHOLD: u32 = 7 * DAY_IN_LEDGERS;
 pub const PERSISTENT_EXTEND_TO: u32 = 30 * DAY_IN_LEDGERS;
+pub const MAX_PLUGINS: u32 = 10;
 
 pub const TOPIC_SIGNER: soroban_sdk::Symbol = symbol_short!("signer");
 pub const TOPIC_PLUGIN: soroban_sdk::Symbol = symbol_short!("plugin");

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -131,3 +131,42 @@ fn test_uninstall_plugin_persists_removal() {
         "Plugin should NOT receive on_auth after uninstall"
     );
 }
+
+// -----------------------------------------------------------------------------
+// Test: Installing more than MAX_PLUGINS plugins fails with MaxPluginsReached
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_max_plugins_limit() {
+    let env = setup();
+    env.mock_all_auths();
+
+    // Deploy SmartAccount with one admin signer
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Install 10 plugins (the maximum allowed)
+    for i in 0..10u32 {
+        let plugin_id = env.register(DummyPlugin, ());
+        env.as_contract(&smart_account_id, || {
+            SmartAccount::install_plugin(&env, plugin_id.clone())
+        })
+        .unwrap_or_else(|e| panic!("Plugin {} install should succeed but got: {:?}", i, e));
+    }
+
+    // The 11th plugin should fail with MaxPluginsReached
+    let extra_plugin_id = env.register(DummyPlugin, ());
+    let err = env
+        .as_contract(&smart_account_id, || {
+            SmartAccount::install_plugin(&env, extra_plugin_id.clone())
+        })
+        .unwrap_err();
+
+    assert_eq!(err, Error::MaxPluginsReached);
+}


### PR DESCRIPTION
## Why
The plugin map in instance storage can grow without bound. Since `call_plugins_on_auth` iterates all plugins on every `__check_auth` invocation, unbounded growth causes progressive gas cost inflation on every transaction. At extreme counts, the plugin map can exceed instance storage limits entirely.

## Summary
- Adds `MAX_PLUGINS = 10` constant and `MaxPluginsReached` error variant
- Checks plugin count before insertion in `install_plugin()`

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `test_max_plugins_limit`: verifies installing 10 plugins succeeds and the 11th returns `MaxPluginsReached`
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/stellar-smart-account/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
