### PR TITLE
fix(FIND-008): distinguish plugin rejection from technical failure in auth

### DIFF
--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -83,7 +83,18 @@ impl Authorizer {
                 .try_on_auth(&env.current_contract_address(), auth_contexts);
             match res {
                 // Plugin executed successfully
-                Ok(_) => {}
+                Ok(Ok(_)) => {}
+                // Plugin return value conversion failure (ABI mismatch)
+                // Treat as technical failure: log and continue
+                Ok(Err(_)) => {
+                    env.events().publish(
+                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
+                        PluginAuthFailedEvent {
+                            plugin: plugin.clone(),
+                            error: String::from_str(env, "Plugin return type mismatch (skipped)"),
+                        },
+                    );
+                }
                 // Plugin intentionally rejected (contracterror / panic_with_error!)
                 Err(Ok(_)) => {
                     env.events().publish(

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -7,7 +7,6 @@ use crate::config::{
 };
 use crate::error::Error;
 use crate::events::PluginAuthFailedEvent;
-use crate::handle_nested_result_failure;
 use smart_account_interfaces::SmartAccountPluginClient;
 use smart_account_interfaces::{Signer, SignerKey, SignerRole};
 use soroban_sdk::{auth::Context, crypto::Hash, Env, Vec};
@@ -82,16 +81,32 @@ impl Authorizer {
         {
             let res = SmartAccountPluginClient::new(env, &plugin)
                 .try_on_auth(&env.current_contract_address(), auth_contexts);
-            handle_nested_result_failure!(res, {
-                env.events().publish(
-                    (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
-                    PluginAuthFailedEvent {
-                        plugin: plugin.clone(),
-                        error: String::from_str(env, "Plugin on_auth failed"),
-                    },
-                );
-                return Err(Error::PluginOnAuthFailed);
-            });
+            match res {
+                // Plugin executed successfully
+                Ok(_) => {}
+                // Plugin intentionally rejected (contracterror / panic_with_error!)
+                Err(Ok(_)) => {
+                    env.events().publish(
+                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
+                        PluginAuthFailedEvent {
+                            plugin: plugin.clone(),
+                            error: String::from_str(env, "Plugin rejected authorization"),
+                        },
+                    );
+                    return Err(Error::PluginOnAuthFailed);
+                }
+                // Plugin had a technical failure (panic!, host trap, TTL expiry)
+                // Non-blocking: log and continue to next plugin
+                Err(Err(_)) => {
+                    env.events().publish(
+                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
+                        PluginAuthFailedEvent {
+                            plugin: plugin.clone(),
+                            error: String::from_str(env, "Plugin technical failure (skipped)"),
+                        },
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -77,15 +77,6 @@ mod rejecting_plugin {
 
 use rejecting_plugin::RejectingPlugin;
 
-// NOTE: Testing the Err(Err(_)) branch (technical failure / panic!) is not
-// feasible in the Soroban test harness. In native test mode, a panic! inside a
-// cross-contract `try_call` is caught and re-raised as a WasmVm error which the
-// host then escalates through `call_account_contract_check_auth`, causing the
-// outer `try_invoke_contract_check_auth` to see a contract-level failure rather
-// than letting `call_plugins_on_auth` gracefully skip the plugin.
-// In production (Wasm), a panic! in a plugin produces Err(Err(InvokeError))
-// at the try_on_auth level, allowing the smart account to log-and-skip it.
-
 // -----------------------------------------------------------------------------
 // Test: Uninstall properly persists removal, plugin no longer receives on_auth
 // -----------------------------------------------------------------------------

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -45,6 +45,48 @@ impl DummyPlugin {
 }
 
 // -----------------------------------------------------------------------------
+// Plugin that intentionally rejects authorization (panic_with_error!)
+// Wrapped in a submodule to avoid contractimpl symbol collisions.
+// -----------------------------------------------------------------------------
+
+mod rejecting_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, panic_with_error, Address, Env, Vec};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct RejectingPlugin;
+
+    #[contractimpl]
+    impl RejectingPlugin {
+        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
+            // This uses panic_with_error! which produces Err(Ok(e)) in try_on_auth,
+            // meaning the plugin intentionally rejected authorization.
+            panic_with_error!(env, Error::PluginOnAuthFailed);
+        }
+    }
+}
+
+use rejecting_plugin::RejectingPlugin;
+
+// NOTE: Testing the Err(Err(_)) branch (technical failure / panic!) is not
+// feasible in the Soroban test harness. In native test mode, a panic! inside a
+// cross-contract `try_call` is caught and re-raised as a WasmVm error which the
+// host then escalates through `call_account_contract_check_auth`, causing the
+// outer `try_invoke_contract_check_auth` to see a contract-level failure rather
+// than letting `call_plugins_on_auth` gracefully skip the plugin.
+// In production (Wasm), a panic! in a plugin produces Err(Err(InvokeError))
+// at the try_on_auth level, allowing the smart account to log-and-skip it.
+
+// -----------------------------------------------------------------------------
 // Test: Uninstall properly persists removal, plugin no longer receives on_auth
 // -----------------------------------------------------------------------------
 
@@ -130,4 +172,48 @@ fn test_uninstall_plugin_persists_removal() {
         count_after_uninstall, 1,
         "Plugin should NOT receive on_auth after uninstall"
     );
+}
+
+// -----------------------------------------------------------------------------
+// Test: Intentional plugin rejection blocks authorization
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_plugin_intentional_rejection_blocks_auth() {
+    let env = setup();
+    env.mock_all_auths();
+
+    // Deploy SmartAccount with one admin signer
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Deploy and install the rejecting plugin
+    let plugin_id = env.register(RejectingPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    // Try to authenticate
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // The rejecting plugin (panic_with_error!) should cause PluginOnAuthFailed,
+    // blocking authorization. This exercises the Err(Ok(_)) branch in
+    // call_plugins_on_auth.
+    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }


### PR DESCRIPTION
## Why
A technically-failing plugin (e.g., one whose WASM expired, panics during execution, or has an ABI mismatch after upgrade) blocks ALL `__check_auth` calls — including the `uninstall_plugin` call needed to remove it. This creates a permanent deadlock: the account cannot authorize any transaction because the plugin fails, but the plugin cannot be removed because removal requires authorization.

## Summary
- Replaces `handle_nested_result_failure!` with explicit match on Soroban's nested Result:
  - `Ok(Ok(_))`: success → continue
  - `Ok(Err(_))`: ABI mismatch → log and skip (non-blocking)
  - `Err(Ok(_))`: intentional rejection (`panic_with_error!`) → block auth
  - `Err(Err(_))`: technical failure (`panic!`, host trap) → log and skip (non-blocking)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] All four match arms explicitly handled
- [x] Addressed review comment: `Ok(Err(_))` ABI mismatch treated as technical failure