### PR TITLE
fix(FIND-004): reject upgrade() when a migration is already pending

### DIFF
--- a/contracts/upgradeable/src/lib.rs
+++ b/contracts/upgradeable/src/lib.rs
@@ -9,6 +9,7 @@ use soroban_sdk::{
 #[repr(u32)]
 pub enum Error {
     MigrationNotAllowed = 1100,
+    MigrationAlreadyPending = 1110,
 }
 
 pub const MIGRATING: Symbol = symbol_short!("MIGRATING");
@@ -16,6 +17,7 @@ pub const MIGRATING: Symbol = symbol_short!("MIGRATING");
 pub trait SmartAccountUpgradeable: SmartAccountUpgradeableAuth {
     fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
         Self::_require_auth_upgrade(env);
+        ensure_no_pending_migration(env);
         enable_migration(env);
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
@@ -26,6 +28,7 @@ pub trait SmartAccountUpgradeableMigratable:
 {
     fn upgrade(e: &soroban_sdk::Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
         Self::_require_auth_upgrade(e);
+        ensure_no_pending_migration(e);
         enable_migration(e);
         e.events().publish(
             (Symbol::new(e, "UPGRADE_STARTED"),),
@@ -69,6 +72,7 @@ macro_rules! impl_upgradeable {
         impl SmartAccountUpgradeable for $contract_type {
             fn upgrade(env: &soroban_sdk::Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
                 Self::_require_auth_upgrade(env);
+                $crate::ensure_no_pending_migration(env);
                 $crate::enable_migration(env);
                 env.deployer().update_current_contract_wasm(new_wasm_hash);
             }
@@ -95,6 +99,7 @@ macro_rules! impl_upgradeable_migratable {
         impl $contract_type {
             pub fn upgrade(e: &soroban_sdk::Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
                 Self::_require_auth_upgrade(e);
+                $crate::ensure_no_pending_migration(e);
                 $crate::enable_migration(e);
                 e.events().publish(
                     (soroban_sdk::Symbol::new(e, "UPGRADE_STARTED"),),
@@ -130,6 +135,11 @@ pub fn can_complete_migration(e: &Env) -> bool {
 }
 pub fn complete_migration(e: &Env) {
     e.storage().instance().set(&MIGRATING, &false);
+}
+pub fn ensure_no_pending_migration(e: &Env) {
+    if can_complete_migration(e) {
+        panic_with_error!(e, Error::MigrationAlreadyPending)
+    }
 }
 pub fn enable_migration(e: &Env) {
     e.storage().instance().set(&MIGRATING, &true);

--- a/contracts/upgradeable/src/lib.rs
+++ b/contracts/upgradeable/src/lib.rs
@@ -17,7 +17,6 @@ pub const MIGRATING: Symbol = symbol_short!("MIGRATING");
 pub trait SmartAccountUpgradeable: SmartAccountUpgradeableAuth {
     fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
         Self::_require_auth_upgrade(env);
-        ensure_no_pending_migration(env);
         enable_migration(env);
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
@@ -72,7 +71,6 @@ macro_rules! impl_upgradeable {
         impl SmartAccountUpgradeable for $contract_type {
             fn upgrade(env: &soroban_sdk::Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
                 Self::_require_auth_upgrade(env);
-                $crate::ensure_no_pending_migration(env);
                 $crate::enable_migration(env);
                 env.deployer().update_current_contract_wasm(new_wasm_hash);
             }

--- a/contracts/upgradeable/src/test.rs
+++ b/contracts/upgradeable/src/test.rs
@@ -1,1 +1,37 @@
 #![cfg(test)]
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+use crate::{complete_migration, enable_migration, ensure_no_pending_migration};
+
+#[contract]
+pub struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1110)")]
+fn test_upgrade_rejected_when_migration_pending() {
+    let env = Env::default();
+    let contract_id = env.register(DummyContract, ());
+
+    env.as_contract(&contract_id, || {
+        enable_migration(&env);
+        // A second upgrade attempt while migration is pending must fail.
+        ensure_no_pending_migration(&env);
+    });
+}
+
+#[test]
+fn test_upgrade_allowed_after_migration_completes() {
+    let env = Env::default();
+    let contract_id = env.register(DummyContract, ());
+
+    env.as_contract(&contract_id, || {
+        enable_migration(&env);
+        complete_migration(&env);
+        // After migration completes, another upgrade should be allowed.
+        ensure_no_pending_migration(&env);
+    });
+}


### PR DESCRIPTION
## Why
`upgrade()` unconditionally sets `MIGRATING=true` with no check for whether a migration is already pending. A second `upgrade()` call before `migrate()` completes silently replaces the pending WASM hash, potentially causing the migration logic from a different WASM version to run against stale or incompatible data when `migrate()` is eventually called.

## Summary
- Adds `ensure_no_pending_migration()` guard in migratable upgrade paths only
- Non-migratable paths (`SmartAccountUpgradeable` / `impl_upgradeable!`) are not guarded since they have no `migrate()`/`complete_migration()` step to reset the flag
- New error: `MigrationAlreadyPending` (1110)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `test_upgrade_rejected_when_migration_pending`: guard panics when MIGRATING=true
- [x] `test_upgrade_allowed_after_migration_completes`: guard passes after `complete_migration`
- [x] Addressed review comment: guard removed from non-migratable path