### PR TITLE
refactor(FIND-010): enforce CQS in TokenTransferPolicy authorization

### DIFF
--- a/contracts/smart-account/src/auth/permissions.rs
+++ b/contracts/smart-account/src/auth/permissions.rs
@@ -8,6 +8,10 @@ use smart_account_interfaces::{SignerKey, SignerPolicy, SignerRole};
 
 pub trait AuthorizationCheck {
     fn is_authorized(&self, env: &Env, signer_key: &SignerKey, context: &Vec<Context>) -> bool;
+
+    /// Called after authorization succeeds to commit any side effects (e.g. spending tracker).
+    /// Default is a no-op for policies with no state to commit.
+    fn on_authorized(&self, _env: &Env, _signer_key: &SignerKey, _context: &Vec<Context>) {}
 }
 
 pub trait PolicyCallback {
@@ -26,6 +30,17 @@ impl AuthorizationCheck for SignerPolicy {
             }
             SignerPolicy::TokenTransferPolicy(policy) => {
                 policy.is_authorized(env, signer_key, contexts)
+            }
+        }
+    }
+
+    fn on_authorized(&self, env: &Env, signer_key: &SignerKey, contexts: &Vec<Context>) {
+        match self {
+            SignerPolicy::ExternalValidatorPolicy(policy) => {
+                policy.on_authorized(env, signer_key, contexts)
+            }
+            SignerPolicy::TokenTransferPolicy(policy) => {
+                policy.on_authorized(env, signer_key, contexts)
             }
         }
     }
@@ -78,9 +93,15 @@ impl AuthorizationCheck for SignerRole {
                         // No policies = no restrictions (beyond admin check)
                         None => true,
                         // At least one policy must authorize the full transaction
-                        Some(policies) => policies
-                            .iter()
-                            .any(|policy| policy.is_authorized(env, signer_key, contexts)),
+                        Some(policies) => {
+                            for policy in policies.iter() {
+                                if policy.is_authorized(env, signer_key, contexts) {
+                                    policy.on_authorized(env, signer_key, contexts);
+                                    return true;
+                                }
+                            }
+                            false
+                        }
                     }
                 }
             }

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -11,109 +11,148 @@ use smart_account_interfaces::{
     SignerKey, SmartAccountError, SpendTrackerKey, SpendingTracker, TokenTransferPolicy,
 };
 
+/// Extracts the total transfer amount from a set of contexts, returning None
+/// if any context is invalid for this policy.
+fn extract_transfer_total(
+    policy: &TokenTransferPolicy,
+    env: &Env,
+    contexts: &Vec<Context>,
+) -> Option<i128> {
+    let mut total_amount: i128 = 0;
+
+    for context in contexts.iter() {
+        match context {
+            Context::Contract(contract_context) => {
+                let ContractContext {
+                    contract,
+                    fn_name,
+                    args,
+                } = contract_context;
+
+                if contract != policy.token {
+                    return None;
+                }
+                if fn_name != symbol_short!("transfer") {
+                    return None;
+                }
+                if args.len() != 3 {
+                    return None;
+                }
+
+                // Check recipient allowlist if configured
+                if let Some(recipients) = &policy.allowed_recipients {
+                    if let Ok(recipient) = Address::try_from_val(env, &args.get(1).unwrap()) {
+                        if !recipients.iter().any(|a| a == recipient) {
+                            return None;
+                        }
+                    } else {
+                        return None;
+                    }
+                }
+
+                // Extract transfer amount
+                if let Ok(amount) = i128::try_from_val(env, &args.get(2).unwrap()) {
+                    if amount < 0 {
+                        return None;
+                    }
+                    total_amount = total_amount.checked_add(amount).unwrap_or(i128::MAX);
+                } else {
+                    return None;
+                }
+            }
+            _ => {
+                return None;
+            }
+        }
+    }
+
+    Some(total_amount)
+}
+
+/// Loads the spending tracker and computes the proposed new total.
+/// Returns None if the new total would exceed the limit.
+fn check_spending_limit(
+    policy: &TokenTransferPolicy,
+    env: &Env,
+    signer_key: &SignerKey,
+    total_amount: i128,
+) -> Option<(SpendTrackerKey, SpendingTracker)> {
+    let limit = policy.limit?;
+    let now = env.ledger().timestamp();
+
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
+    let mut tracker: SpendingTracker = env
+        .storage()
+        .persistent()
+        .get(&tracker_key)
+        .unwrap_or(SpendingTracker {
+            spent: 0,
+            window_start: now,
+        });
+
+    // Check if the spending window should reset
+    if policy.reset_window_secs > 0
+        && now.saturating_sub(tracker.window_start) >= policy.reset_window_secs
+    {
+        tracker.spent = 0;
+        tracker.window_start = now;
+    }
+
+    let new_total = tracker.spent.checked_add(total_amount).unwrap_or(i128::MAX);
+    if new_total > limit {
+        return None;
+    }
+
+    tracker.spent = new_total;
+    Some((tracker_key, tracker))
+}
+
+/// Commits the updated spending tracker to persistent storage.
+fn record_spend(env: &Env, tracker_key: &SpendTrackerKey, tracker: &SpendingTracker) {
+    env.storage().persistent().set(tracker_key, tracker);
+    env.storage().persistent().extend_ttl(
+        tracker_key,
+        PERSISTENT_TTL_THRESHOLD,
+        PERSISTENT_EXTEND_TO,
+    );
+}
+
 impl AuthorizationCheck for TokenTransferPolicy {
     fn is_authorized(&self, env: &Env, signer_key: &SignerKey, contexts: &Vec<Context>) -> bool {
-        let now = env.ledger().timestamp();
-
         // 1. Check expiration
-        if self.expiration > 0 && now > self.expiration {
+        if self.expiration > 0 && env.ledger().timestamp() > self.expiration {
             return false;
         }
 
-        // 2. Validate ALL contexts are `transfer` on the specified token
-        let mut total_amount: i128 = 0;
+        // 2. Validate contexts and extract total transfer amount
+        let total_amount = match extract_transfer_total(self, env, contexts) {
+            Some(amount) => amount,
+            None => return false,
+        };
 
-        for context in contexts.iter() {
-            match context {
-                Context::Contract(contract_context) => {
-                    let ContractContext {
-                        contract,
-                        fn_name,
-                        args,
-                    } = contract_context;
-
-                    // Must be the specific token contract
-                    if contract != self.token {
-                        return false;
-                    }
-
-                    // Must be the "transfer" function
-                    if fn_name != symbol_short!("transfer") {
-                        return false;
-                    }
-
-                    // transfer(from, to, amount): args[0]=from, args[1]=to, args[2]=amount
-                    if args.len() != 3 {
-                        return false;
-                    }
-
-                    // Check recipient allowlist if configured
-                    if let Some(recipients) = &self.allowed_recipients {
-                        if let Ok(recipient) = Address::try_from_val(env, &args.get(1).unwrap()) {
-                            if !recipients.iter().any(|a| a == recipient) {
-                                return false;
-                            }
-                        } else {
-                            return false;
-                        }
-                    }
-
-                    // Extract transfer amount
-                    if let Ok(amount) = i128::try_from_val(env, &args.get(2).unwrap()) {
-                        if amount < 0 {
-                            return false;
-                        }
-                        total_amount = total_amount.checked_add(amount).unwrap_or(i128::MAX);
-                    } else {
-                        return false;
-                    }
-                }
-                _ => {
-                    // Non-contract contexts are not allowed
-                    return false;
-                }
-            }
-        }
-
-        // 3. Enforce cumulative limit if configured
-        if let Some(limit) = self.limit {
-            // Load spending tracker
-            let tracker_key =
-                SpendTrackerKey::TokenSpend(self.policy_id.clone(), signer_key.clone());
-            let mut tracker: SpendingTracker = env
-                .storage()
-                .persistent()
-                .get(&tracker_key)
-                .unwrap_or(SpendingTracker {
-                    spent: 0,
-                    window_start: now,
-                });
-
-            // Check if the spending window should reset
-            if self.reset_window_secs > 0
-                && now.saturating_sub(tracker.window_start) >= self.reset_window_secs
-            {
-                tracker.spent = 0;
-                tracker.window_start = now;
-            }
-
-            // Check cumulative limit
-            let new_total = tracker.spent.checked_add(total_amount).unwrap_or(i128::MAX);
-            if new_total > limit {
+        // 3. Enforce cumulative spending limit (read-only check)
+        if self.limit.is_some() {
+            if check_spending_limit(self, env, signer_key, total_amount).is_none() {
                 return false;
             }
-
-            // Update spending tracker
-            tracker.spent = new_total;
-            env.storage().persistent().set(&tracker_key, &tracker);
-            env.storage().persistent().extend_ttl(
-                &tracker_key,
-                PERSISTENT_TTL_THRESHOLD,
-                PERSISTENT_EXTEND_TO,
-            );
         }
 
         true
+    }
+
+    fn on_authorized(&self, env: &Env, signer_key: &SignerKey, contexts: &Vec<Context>) {
+        if self.limit.is_none() {
+            return;
+        }
+
+        let total_amount = match extract_transfer_total(self, env, contexts) {
+            Some(amount) => amount,
+            None => return,
+        };
+
+        if let Some((tracker_key, tracker)) = check_spending_limit(self, env, signer_key, total_amount) {
+            record_spend(env, &tracker_key, &tracker);
+        }
     }
 }
 

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -81,14 +81,14 @@ fn check_spending_limit(
     let now = env.ledger().timestamp();
 
     let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
-    let mut tracker: SpendingTracker = env
-        .storage()
-        .persistent()
-        .get(&tracker_key)
-        .unwrap_or(SpendingTracker {
-            spent: 0,
-            window_start: now,
-        });
+    let mut tracker: SpendingTracker =
+        env.storage()
+            .persistent()
+            .get(&tracker_key)
+            .unwrap_or(SpendingTracker {
+                spent: 0,
+                window_start: now,
+            });
 
     // Check if the spending window should reset
     if policy.reset_window_secs > 0
@@ -150,7 +150,9 @@ impl AuthorizationCheck for TokenTransferPolicy {
             None => return,
         };
 
-        if let Some((tracker_key, tracker)) = check_spending_limit(self, env, signer_key, total_amount) {
+        if let Some((tracker_key, tracker)) =
+            check_spending_limit(self, env, signer_key, total_amount)
+        {
             record_spend(env, &tracker_key, &tracker);
         }
     }

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -131,10 +131,10 @@ impl AuthorizationCheck for TokenTransferPolicy {
         };
 
         // 3. Enforce cumulative spending limit (read-only check)
-        if self.limit.is_some() {
-            if check_spending_limit(self, env, signer_key, total_amount).is_none() {
-                return false;
-            }
+        if self.limit.is_some()
+            && check_spending_limit(self, env, signer_key, total_amount).is_none()
+        {
+            return false;
         }
 
         true

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -3,12 +3,13 @@ use soroban_sdk::testutils::{Address as _, BytesN as _, Ledger as _};
 use soroban_sdk::{map, vec, Address, BytesN, Env, IntoVal, Vec};
 
 use crate::account::SmartAccount;
+use crate::auth::permissions::AuthorizationCheck;
 use crate::auth::proof::SignatureProofs;
 use crate::error::Error;
 use crate::tests::test_utils::{setup, Ed25519TestSigner, TestSignerTrait as _};
 use smart_account_interfaces::{
     SignerKey, SignerPolicy, SignerRole, SmartAccountInterface as _, SpendTrackerKey,
-    TokenTransferPolicy,
+    SpendingTracker, TokenTransferPolicy,
 };
 
 // ============================================================================
@@ -821,4 +822,43 @@ fn test_standard_some_empty_vec_rejected() {
             Vec::<Address>::new(&env),
         ),
     );
+}
+
+// ============================================================================
+// Read-only predicate tests (is_authorized must not write)
+// ============================================================================
+
+#[test]
+fn test_is_authorized_does_not_write_tracker() {
+    let env = setup();
+    let token = Address::generate(&env);
+    let policy = make_policy(&env, &token, Some(1000));
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+
+    let to = Address::generate(&env);
+
+    // 1. Execute a full check_auth for 500 (calls both is_authorized and on_authorized).
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 500)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap();
+
+    let signer_key = SignerKey::Ed25519(signer.public_key(&env));
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
+
+    // 2. Verify the tracker now shows spent = 500.
+    env.as_contract(&contract_id, || {
+        let tracker: SpendingTracker = env.storage().persistent().get(&tracker_key).unwrap();
+        assert_eq!(tracker.spent, 500);
+    });
+
+    // 3. Call ONLY is_authorized (the read-only predicate) for an additional 200.
+    //    700 < 1000, so it should return true, but must NOT update the tracker.
+    let contexts_200 = vec![&env, make_transfer_context(&env, &token, &to, 200)];
+    env.as_contract(&contract_id, || {
+        let result = policy.is_authorized(&env, &signer_key, &contexts_200);
+        assert!(result);
+
+        // 4. Verify the tracker was NOT modified -- still 500, not 700.
+        let tracker: SpendingTracker = env.storage().persistent().get(&tracker_key).unwrap();
+        assert_eq!(tracker.spent, 500);
+    });
 }


### PR DESCRIPTION
## Why
`TokenTransferPolicy::is_authorized()` writes the updated spending tracker to persistent storage inside what callers expect to be a read-only predicate. This violates Command-Query Separation: authorization checks in Soroban are conventionally read-only, and any future refactoring that calls `is_authorized` more than once (e.g., for dry-run checks, logging, or policy comparison) would silently deplete the spending budget without any actual token movement.

## Summary
- `is_authorized()` is now a pure read-only predicate — no storage writes
- `on_authorized()` new trait callback commits the spending tracker write after authorization is confirmed
- `SignerRole` orchestrates the call: finds the matching policy via `is_authorized()`, then calls `on_authorized()` on it
- Extracted shared helpers: `extract_transfer_total()`, `check_spending_limit()`, `record_spend()`

## Test plan
- [x] `cargo build` passes (no warnings)
- [x] `cargo test` passes (all existing + new tests)
- [x] `test_is_authorized_does_not_write_tracker`: verifies calling `is_authorized` alone does not mutate storage
- [x] Existing spending limit tests verify tracker is still updated correctly through the full `__check_auth` flow
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/stellar-smart-account/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
