### PR TITLE
fix(FIND-005): recalculate admin_cnt from migrated signers

### DIFF
--- a/contracts/smart-account/src/migration/v1_to_v2.rs
+++ b/contracts/smart-account/src/migration/v1_to_v2.rs
@@ -11,9 +11,10 @@ use smart_account_interfaces::{
     WebauthnSigner,
 };
 use soroban_sdk::{contracttype, Env, Vec};
+use storage::Storage;
 
 use super::v1_types::{V1Signer, V1SignerKey, V1SignerPolicy, V1SignerRole};
-use crate::config::{PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
+use crate::config::{ADMIN_COUNT_KEY, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
 
 /// Data required by the migration function.
 /// The caller must provide the list of v1 signer keys that need migration.
@@ -31,12 +32,25 @@ pub struct V1ToV2MigrationData {
 /// - Deletes the old storage entry
 /// - Writes the new entry with V2 key and value
 pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) -> Result<(), SmartAccountError> {
+    if data.signers_to_migrate.is_empty() {
+        return Err(SmartAccountError::NoSigners);
+    }
+
+    let mut admin_count: u32 = 0;
+
     for old_key in data.signers_to_migrate.iter() {
         let old_signer: V1Signer = env
             .storage()
             .persistent()
             .get(&old_key)
             .ok_or(SmartAccountError::MigrationSignerNotFound)?;
+
+        let role = match &old_signer {
+            V1Signer::Ed25519(_, role) | V1Signer::Secp256r1(_, role) => role,
+        };
+        if matches!(role, V1SignerRole::Admin) {
+            admin_count += 1;
+        }
 
         // Remove the old entry
         env.storage().persistent().remove(&old_key);
@@ -50,6 +64,14 @@ pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) -> Result<(), Sma
             PERSISTENT_EXTEND_TO,
         );
     }
+
+    if admin_count == 0 {
+        return Err(SmartAccountError::NoSigners);
+    }
+
+    // Overwrite admin_cnt with the actual count from migrated signers
+    Storage::persistent().update(env, &ADMIN_COUNT_KEY, &admin_count)?;
+
     Ok(())
 }
 

--- a/contracts/smart-account/src/migration/v1_to_v2.rs
+++ b/contracts/smart-account/src/migration/v1_to_v2.rs
@@ -32,11 +32,7 @@ pub struct V1ToV2MigrationData {
 /// - Deletes the old storage entry
 /// - Writes the new entry with V2 key and value
 pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) -> Result<(), SmartAccountError> {
-    if data.signers_to_migrate.is_empty() {
-        return Err(SmartAccountError::NoSigners);
-    }
-
-    let mut admin_count: u32 = 0;
+    let mut migrated_admin_count: u32 = 0;
 
     for old_key in data.signers_to_migrate.iter() {
         let old_signer: V1Signer = env
@@ -49,7 +45,7 @@ pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) -> Result<(), Sma
             V1Signer::Ed25519(_, role) | V1Signer::Secp256r1(_, role) => role,
         };
         if matches!(role, V1SignerRole::Admin) {
-            admin_count += 1;
+            migrated_admin_count += 1;
         }
 
         // Remove the old entry
@@ -65,12 +61,12 @@ pub fn migrate_v1_to_v2(env: &Env, data: &V1ToV2MigrationData) -> Result<(), Sma
         );
     }
 
-    if admin_count == 0 {
-        return Err(SmartAccountError::NoSigners);
+    // If any admin signers were in the migrated set, recalculate admin_cnt
+    // from the migrated set to prevent desync from orphaned V1 admins.
+    // For partial migrations with no admins, the existing count is preserved.
+    if migrated_admin_count > 0 {
+        Storage::persistent().update(env, &ADMIN_COUNT_KEY, &migrated_admin_count)?;
     }
-
-    // Overwrite admin_cnt with the actual count from migrated signers
-    Storage::persistent().update(env, &ADMIN_COUNT_KEY, &admin_count)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Why
`migrate_v1_to_v2` accepts a caller-supplied list of signer keys but never recalculates `admin_cnt`. If a V1 admin is omitted from the list, it becomes permanently inaccessible under the V2 key schema while still being counted in `admin_cnt`. This inflated counter allows `decrement_admin_count` to authorize downgrading the last *functional* admin to Standard, permanently locking the account.

## Summary
- Count admin signers during migration as they are converted
- When admins are part of the migrated set, overwrite `ADMIN_COUNT_KEY` with the actual count
- When no admins are in the migrated set (partial migration of non-admin signers only), preserve the existing count
- Empty migration payloads are allowed (Ed25519-only accounts need no key conversion)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (125 tests, including existing upgrade tests)
- [x] Addressed review: empty migrations allowed for Ed25519-only accounts
- [x] Addressed review: partial migrations without admins preserve existing admin count