### PR TITLE
fix(FIND-006): reorder WebAuthn verify to fail-fast before crypto

### DIFF
--- a/contracts/smart-account/src/auth/signers/webauthn.rs
+++ b/contracts/smart-account/src/auth/signers/webauthn.rs
@@ -25,35 +25,40 @@ impl SignatureVerifier for WebauthnSigner {
                     signature,
                 } = signature.clone();
 
-                authenticator_data
-                    .extend_from_array(&env.crypto().sha256(&client_data_json).to_array());
+                // Cheap checks first — reject malformed inputs before expensive crypto
 
-                // This will panic if the signature is invalid
-                env.crypto().secp256r1_verify(
-                    &self.public_key,
-                    &env.crypto().sha256(&authenticator_data),
-                    &signature,
-                );
+                // WebAuthn authenticator data: rpIdHash (32) + flags (1) + signCount (4) = 37 min
+                if authenticator_data.len() < 37 {
+                    return Err(Error::InvalidWebauthnClientDataJson);
+                }
 
                 if client_data_json.len() > 1024 {
                     return Err(Error::InvalidWebauthnClientDataJson);
                 }
 
-                let client_data_json = client_data_json.to_buffer::<1024>();
-                let client_data_json = client_data_json.as_slice();
-                let (client_data_json, _): (ClientDataJson, _) =
-                    serde_json_core::de::from_slice(client_data_json)
+                let client_data_json_buf = client_data_json.to_buffer::<1024>();
+                let (parsed_client_data, _): (ClientDataJson, _) =
+                    serde_json_core::de::from_slice(client_data_json_buf.as_slice())
                         .map_err(|_| Error::InvalidWebauthnClientDataJson)?;
 
                 let mut buf = [0u8; 64];
                 let expected_challenge =
                     Base64UrlUnpadded::encode(&signature_payload.to_bytes().to_array(), &mut buf)
                         .map_err(|_| Error::InvalidWebauthnClientDataJson)?;
-                if client_data_json.challenge.as_bytes() != expected_challenge.as_bytes() {
+                if parsed_client_data.challenge.as_bytes() != expected_challenge.as_bytes() {
                     return Err(Error::ClientDataJsonIncorrectChallenge);
                 }
 
-                // Reaching this point means the signature is valid
+                // Expensive crypto — only reached for structurally valid inputs
+                authenticator_data
+                    .extend_from_array(&env.crypto().sha256(&client_data_json).to_array());
+
+                env.crypto().secp256r1_verify(
+                    &self.public_key,
+                    &env.crypto().sha256(&authenticator_data),
+                    &signature,
+                );
+
                 Ok(())
             }
             _ => Err(Error::InvalidProofType),


### PR DESCRIPTION
## Why
`WebauthnSigner::verify` runs SHA256 + secp256r1_verify (the most expensive operations) before checking client_data_json length, parsing the JSON, or validating the challenge binding. This wastes gas on malformed inputs that would be immediately rejected by cheaper guards. Additionally, `authenticator_data` is accepted without any length validation, contrary to the WebAuthn spec which mandates a 37-byte minimum structure.

## Summary
- Reorder verification to fail-fast: length checks → JSON parse → challenge validation → crypto
- Add `authenticator_data` minimum length check (>= 37 bytes: rpIdHash + flags + signCount)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (125 tests, including all WebAuthn signer tests)