### PR TITLE
fix: change on_auth to return Result<(), PluginRejection> and fix error classification

### DIFF
--- a/contracts/examples/plugin-policy-example-reverts/src/lib.rs
+++ b/contracts/examples/plugin-policy-example-reverts/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use smart_account_interfaces::{SmartAccountPlugin, SmartAccountPolicy};
+use smart_account_interfaces::{PluginRejection, SmartAccountPlugin, SmartAccountPolicy};
 use soroban_sdk::{
     auth::{Context, ContractContext},
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, TryFromVal, Vec,
@@ -41,7 +41,7 @@ impl SmartAccountPlugin for PluginPolicyContractReverts {
         source.require_auth();
     }
 
-    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>) {
+    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>) -> Result<(), PluginRejection> {
         source.require_auth();
         // Increment the internal counter
         let current_counter: u32 = env.storage().instance().get(&AUTH_COUNTER_KEY).unwrap_or(0);
@@ -60,6 +60,8 @@ impl SmartAccountPlugin for PluginPolicyContractReverts {
                 counter: new_counter,
             },
         );
+
+        Ok(())
     }
 }
 

--- a/contracts/examples/plugin-policy-example/src/lib.rs
+++ b/contracts/examples/plugin-policy-example/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use smart_account_interfaces::{SmartAccountPlugin, SmartAccountPolicy};
+use smart_account_interfaces::{PluginRejection, SmartAccountPlugin, SmartAccountPolicy};
 use soroban_sdk::{
     auth::{Context, ContractContext},
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, TryFromVal, Vec,
@@ -36,7 +36,7 @@ impl SmartAccountPlugin for PluginPolicyContract {
         source.require_auth();
     }
 
-    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>) {
+    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>) -> Result<(), PluginRejection> {
         source.require_auth();
         // Increment the internal counter
         let current_counter: u32 = env.storage().instance().get(&AUTH_COUNTER_KEY).unwrap_or(0);
@@ -55,6 +55,8 @@ impl SmartAccountPlugin for PluginPolicyContract {
                 counter: new_counter,
             },
         );
+
+        Ok(())
     }
 }
 

--- a/contracts/smart-account-interfaces/src/error.rs
+++ b/contracts/smart-account-interfaces/src/error.rs
@@ -1,5 +1,16 @@
 use soroban_sdk::contracterror;
 
+/// Dedicated rejection signal for the plugin `on_auth` interface.
+///
+/// Plugins return `Err(PluginRejection::Rejected)` to intentionally block
+/// authorization. Any panic is treated as a technical failure and skipped.
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum PluginRejection {
+    Rejected = 1,
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u32)]

--- a/contracts/smart-account-interfaces/src/lib.rs
+++ b/contracts/smart-account-interfaces/src/lib.rs
@@ -12,5 +12,5 @@ pub use auth::types::{
     SignerKey, SignerPolicy, SignerRole, SpendTrackerKey, SpendingTracker, TokenTransferPolicy,
     WebauthnSigner,
 };
-pub use error::SmartAccountError;
+pub use error::{PluginRejection, SmartAccountError};
 pub use plugin::{SmartAccountPlugin, SmartAccountPluginClient};

--- a/contracts/smart-account-interfaces/src/plugin.rs
+++ b/contracts/smart-account-interfaces/src/plugin.rs
@@ -1,8 +1,9 @@
+use crate::error::PluginRejection;
 use soroban_sdk::{auth::Context, contractclient, Address, Env, Vec};
 
 #[contractclient(name = "SmartAccountPluginClient")]
 pub trait SmartAccountPlugin {
     fn on_install(env: &Env, source: Address);
     fn on_uninstall(env: &Env, source: Address);
-    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>);
+    fn on_auth(env: &Env, source: Address, contexts: Vec<Context>) -> Result<(), PluginRejection>;
 }

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -111,9 +111,7 @@ impl Authorizer {
                 // and all errors land in Err(Ok(soroban_sdk::Error)).
                 // We inspect the error type to distinguish intentional
                 // rejection (ScErrorType::Contract) from technical failure.
-                Err(Ok(ref error))
-                    if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) =>
-                {
+                Err(Ok(ref error)) if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
                         PluginAuthFailedEvent {

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -10,8 +10,8 @@ use crate::error::Error;
 use crate::events::PluginAuthFailedEvent;
 use smart_account_interfaces::SmartAccountPluginClient;
 use smart_account_interfaces::{Signer, SignerKey, SignerRole};
-use soroban_sdk::{auth::Context, crypto::Hash, Env, Vec};
-use soroban_sdk::{Address, Map, String, Symbol};
+use soroban_sdk::auth::{Context, ContractContext};
+use soroban_sdk::{crypto::Hash, Address, Env, InvokeError, Map, String, Symbol, TryFromVal, Vec};
 use storage::Storage;
 
 pub struct Authorizer;
@@ -83,19 +83,29 @@ impl Authorizer {
     }
 
     pub fn call_plugins_on_auth(env: &Env, auth_contexts: &Vec<Context>) -> Result<(), Error> {
+        let skip_plugin = Self::plugin_being_uninstalled(env, auth_contexts);
+
         let storage = Storage::instance();
         for (plugin, _) in storage
             .get::<Symbol, Map<Address, ()>>(env, &PLUGINS_KEY)
             .unwrap()
             .iter()
         {
+            // Escape hatch: skip the plugin being uninstalled so it cannot
+            // veto its own removal.
+            if let Some(ref target) = skip_plugin {
+                if plugin == *target {
+                    continue;
+                }
+            }
+
             let res = SmartAccountPluginClient::new(env, &plugin)
                 .try_on_auth(&env.current_contract_address(), auth_contexts);
             match res {
-                // Plugin executed successfully
+                // Plugin approved (new-style Ok(()) or old-style void return —
+                // both produce Void at the ABI level).
                 Ok(Ok(_)) => {}
-                // Plugin return value conversion failure (ABI mismatch)
-                // Treat as technical failure: log and continue
+                // Return value conversion failure (ABI mismatch) — skip.
                 Ok(Err(_)) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
@@ -105,13 +115,8 @@ impl Authorizer {
                         },
                     );
                 }
-                // Plugin invocation failed.
-                // Because on_auth returns () (not Result), the contractclient
-                // macro sets E = soroban_sdk::Error, so try_from never fails
-                // and all errors land in Err(Ok(soroban_sdk::Error)).
-                // We inspect the error type to distinguish intentional
-                // rejection (ScErrorType::Contract) from technical failure.
-                Err(Ok(ref error)) if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) => {
+                // Plugin explicitly rejected via Err(PluginRejection::Rejected).
+                Err(Ok(_)) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
                         PluginAuthFailedEvent {
@@ -121,9 +126,22 @@ impl Authorizer {
                     );
                     return Err(Error::PluginOnAuthFailed);
                 }
-                // Technical failure: host trap, bare panic!, missing function,
+                // Old-style rejection: panic_with_error! with a contract error
+                // code that doesn't match PluginRejection. Treat as rejection
+                // to preserve backwards compatibility with existing plugins.
+                Err(Err(InvokeError::Contract(_))) => {
+                    env.events().publish(
+                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
+                        PluginAuthFailedEvent {
+                            plugin: plugin.clone(),
+                            error: String::from_str(env, "Plugin rejected authorization"),
+                        },
+                    );
+                    return Err(Error::PluginOnAuthFailed);
+                }
+                // Technical failure: bare panic!, missing function, host trap,
                 // budget exhaustion, expired TTL. Non-blocking — skip.
-                Err(_) => {
+                Err(Err(InvokeError::Abort)) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
                         PluginAuthFailedEvent {
@@ -135,5 +153,28 @@ impl Authorizer {
             }
         }
         Ok(())
+    }
+
+    /// If the auth context includes an `uninstall_plugin` call on this
+    /// contract, return the address of the plugin being removed so it can
+    /// be skipped in the plugin auth loop.
+    fn plugin_being_uninstalled(env: &Env, auth_contexts: &Vec<Context>) -> Option<Address> {
+        let self_address = env.current_contract_address();
+        for context in auth_contexts.iter() {
+            if let Context::Contract(ContractContext {
+                contract,
+                fn_name,
+                args,
+            }) = context
+            {
+                if contract == self_address
+                    && fn_name == Symbol::new(env, "uninstall_plugin")
+                    && args.len() > 0
+                {
+                    return Address::try_from_val(env, &args.get(0).unwrap()).ok();
+                }
+            }
+        }
+        None
     }
 }

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -105,8 +105,15 @@ impl Authorizer {
                         },
                     );
                 }
-                // Plugin intentionally rejected (contracterror / panic_with_error!)
-                Err(Ok(_)) => {
+                // Plugin invocation failed.
+                // Because on_auth returns () (not Result), the contractclient
+                // macro sets E = soroban_sdk::Error, so try_from never fails
+                // and all errors land in Err(Ok(soroban_sdk::Error)).
+                // We inspect the error type to distinguish intentional
+                // rejection (ScErrorType::Contract) from technical failure.
+                Err(Ok(ref error))
+                    if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) =>
+                {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
                         PluginAuthFailedEvent {
@@ -116,9 +123,9 @@ impl Authorizer {
                     );
                     return Err(Error::PluginOnAuthFailed);
                 }
-                // Plugin had a technical failure (panic!, host trap, TTL expiry)
-                // Non-blocking: log and continue to next plugin
-                Err(Err(_)) => {
+                // Technical failure: host trap, bare panic!, missing function,
+                // budget exhaustion, expired TTL. Non-blocking — skip.
+                Err(_) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
                         PluginAuthFailedEvent {

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -10,8 +10,8 @@ use crate::error::Error;
 use crate::events::PluginAuthFailedEvent;
 use smart_account_interfaces::SmartAccountPluginClient;
 use smart_account_interfaces::{Signer, SignerKey, SignerRole};
-use soroban_sdk::auth::{Context, ContractContext};
-use soroban_sdk::{crypto::Hash, Address, Env, InvokeError, Map, String, Symbol, TryFromVal, Vec};
+use soroban_sdk::auth::Context;
+use soroban_sdk::{crypto::Hash, Address, Env, InvokeError, Map, String, Symbol, Vec};
 use storage::Storage;
 
 pub struct Authorizer;
@@ -83,22 +83,12 @@ impl Authorizer {
     }
 
     pub fn call_plugins_on_auth(env: &Env, auth_contexts: &Vec<Context>) -> Result<(), Error> {
-        let skip_plugin = Self::plugin_being_uninstalled(env, auth_contexts);
-
         let storage = Storage::instance();
         for (plugin, _) in storage
             .get::<Symbol, Map<Address, ()>>(env, &PLUGINS_KEY)
             .unwrap()
             .iter()
         {
-            // Escape hatch: skip the plugin being uninstalled so it cannot
-            // veto its own removal.
-            if let Some(ref target) = skip_plugin {
-                if plugin == *target {
-                    continue;
-                }
-            }
-
             let res = SmartAccountPluginClient::new(env, &plugin)
                 .try_on_auth(&env.current_contract_address(), auth_contexts);
             match res {
@@ -153,28 +143,5 @@ impl Authorizer {
             }
         }
         Ok(())
-    }
-
-    /// If the auth context includes an `uninstall_plugin` call on this
-    /// contract, return the address of the plugin being removed so it can
-    /// be skipped in the plugin auth loop.
-    fn plugin_being_uninstalled(env: &Env, auth_contexts: &Vec<Context>) -> Option<Address> {
-        let self_address = env.current_contract_address();
-        for context in auth_contexts.iter() {
-            if let Context::Contract(ContractContext {
-                contract,
-                fn_name,
-                args,
-            }) = context
-            {
-                if contract == self_address
-                    && fn_name == Symbol::new(env, "uninstall_plugin")
-                    && args.len() > 0
-                {
-                    return Address::try_from_val(env, &args.get(0).unwrap()).ok();
-                }
-            }
-        }
-        None
     }
 }

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -11,12 +11,16 @@ use crate::{
     account::SmartAccount,
     auth::proof::SignatureProofs,
     error::Error,
-    tests::test_utils::{get_token_auth_context, setup, Ed25519TestSigner, TestSignerTrait as _},
+    tests::test_utils::{
+        get_token_auth_context, get_uninstall_plugin_auth_context, setup, Ed25519TestSigner,
+        TestSignerTrait as _,
+    },
 };
 use smart_account_interfaces::{SignerRole, SmartAccountInterface};
 
 // -----------------------------------------------------------------------------
-// Dummy plugin contract that increments a counter on every on_auth
+// Dummy plugin contract that increments a counter on every on_auth.
+// Returns () (void) — exercises ABI backwards compatibility.
 // -----------------------------------------------------------------------------
 
 const COUNT: Symbol = symbol_short!("cnt");
@@ -45,32 +49,29 @@ impl DummyPlugin {
 }
 
 // -----------------------------------------------------------------------------
-// Plugin that intentionally rejects authorization (panic_with_error!)
-// Wrapped in a submodule to avoid contractimpl symbol collisions.
+// Plugin that rejects via new-style Err(PluginRejection::Rejected).
 // -----------------------------------------------------------------------------
 
 mod rejecting_plugin {
-    use soroban_sdk::{auth::Context, contract, contractimpl, panic_with_error, Address, Env, Vec};
+    use soroban_sdk::{auth::Context, contract, contractimpl, Address, Env, Vec};
 
-    use crate::error::Error;
+    use smart_account_interfaces::PluginRejection;
 
     #[contract]
     pub struct RejectingPlugin;
 
     #[contractimpl]
     impl RejectingPlugin {
-        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
-            Ok(())
-        }
+        pub fn on_install(_env: &Env, _source: Address) {}
 
-        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
-            Ok(())
-        }
+        pub fn on_uninstall(_env: &Env, _source: Address) {}
 
-        pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
-            // This uses panic_with_error! which produces a Contract-type error,
-            // meaning the plugin intentionally rejected authorization.
-            panic_with_error!(env, Error::PluginOnAuthFailed);
+        pub fn on_auth(
+            _env: &Env,
+            _source: Address,
+            _contexts: Vec<Context>,
+        ) -> Result<(), PluginRejection> {
+            Err(PluginRejection::Rejected)
         }
     }
 }
@@ -78,7 +79,7 @@ mod rejecting_plugin {
 use rejecting_plugin::RejectingPlugin;
 
 // -----------------------------------------------------------------------------
-// Plugin that bare-panics (technical failure, no contract error code)
+// Plugin that bare-panics (technical failure, no contract error code).
 // -----------------------------------------------------------------------------
 
 mod panicking_plugin {
@@ -100,8 +101,6 @@ mod panicking_plugin {
         }
 
         pub fn on_auth(_env: &Env, _source: Address, _contexts: Vec<Context>) {
-            // Bare panic! produces Error(Context, InvalidAction) — NOT a
-            // contract error. The authorizer skips this as a technical failure.
             panic!("crashed");
         }
     }
@@ -110,7 +109,9 @@ mod panicking_plugin {
 use panicking_plugin::PanickingPlugin;
 
 // -----------------------------------------------------------------------------
-// Plugin that rejects with its own #[contracterror] (code outside SmartAccountError)
+// Plugin that rejects with old-style panic_with_error! using a custom
+// #[contracterror] (code 200, outside SmartAccountError/PluginRejection).
+// Tests backwards compatibility with existing deployed plugins.
 // -----------------------------------------------------------------------------
 
 mod custom_error_plugin {
@@ -130,19 +131,11 @@ mod custom_error_plugin {
 
     #[contractimpl]
     impl CustomErrorPlugin {
-        pub fn on_install(_env: &Env, _source: Address) {
-            // no-op
-        }
+        pub fn on_install(_env: &Env, _source: Address) {}
 
-        pub fn on_uninstall(_env: &Env, _source: Address) {
-            // no-op
-        }
+        pub fn on_uninstall(_env: &Env, _source: Address) {}
 
         pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
-            // Deliberate rejection using a custom error type whose code (200)
-            // does not match any SmartAccountError variant. This produces
-            // Error(Contract, #200) — still a contract-type error, so the
-            // authorizer must treat it as an intentional rejection.
             panic_with_error!(env, CustomPluginError::Rejected);
         }
     }
@@ -151,7 +144,7 @@ mod custom_error_plugin {
 use custom_error_plugin::CustomErrorPlugin;
 
 // -----------------------------------------------------------------------------
-// Plugin that has on_install but no on_auth (missing callback)
+// Plugin that has on_install but no on_auth (missing callback).
 // -----------------------------------------------------------------------------
 
 mod no_auth_plugin {
@@ -171,13 +164,35 @@ mod no_auth_plugin {
         pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
             Ok(())
         }
-
-        // Deliberately NO on_auth method — simulates a misconfigured or
-        // upgraded contract that lost its on_auth callback.
     }
 }
 
 use no_auth_plugin::NoAuthPlugin;
+
+// =============================================================================
+// Helper: run __check_auth with given auth contexts
+// =============================================================================
+
+fn check_auth(
+    env: &Env,
+    smart_account_id: &Address,
+    admin: &Ed25519TestSigner,
+    contexts: &Vec<Context>,
+) -> Result<(), Result<Error, soroban_sdk::InvokeError>> {
+    let payload = BytesN::random(env);
+    let (admin_key, admin_proof) = admin.sign(env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![env, (admin_key, admin_proof)]);
+    env.try_invoke_contract_check_auth::<Error>(
+        smart_account_id,
+        &payload,
+        auth_payloads.into_val(env),
+        contexts,
+    )
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
 
 // -----------------------------------------------------------------------------
 // Test: Uninstall properly persists removal, plugin no longer receives on_auth
@@ -188,7 +203,6 @@ fn test_uninstall_plugin_persists_removal() {
     let env = setup();
     env.mock_all_auths();
 
-    // Deploy SmartAccount with one admin signer
     let admin = Ed25519TestSigner::generate(SignerRole::Admin);
     let smart_account_id = env.register(
         SmartAccount,
@@ -198,16 +212,13 @@ fn test_uninstall_plugin_persists_removal() {
         ),
     );
 
-    // Deploy dummy plugin
     let plugin_id = env.register(DummyPlugin, ());
-
-    // Install plugin
     env.as_contract(&smart_account_id, || {
         SmartAccount::install_plugin(&env, plugin_id.clone())
     })
     .unwrap();
 
-    // Verify plugin is installed by triggering on_auth
+    // Trigger on_auth
     let payload = BytesN::random(&env);
     let (admin_key, admin_proof) = admin.sign(&env, &payload);
     let auth_payloads = SignatureProofs(soroban_sdk::map![
@@ -223,30 +234,24 @@ fn test_uninstall_plugin_persists_removal() {
     )
     .unwrap();
 
-    // Verify plugin is installed
     assert!(env.as_contract(&smart_account_id, || {
         SmartAccount::is_plugin_installed(&env, plugin_id.clone())
     }));
 
-    // Verify plugin received on_auth call
     let count_after_install = env.as_contract(&plugin_id, || DummyPlugin::get_count(&env));
-    assert_eq!(
-        count_after_install, 1,
-        "Plugin should have received on_auth call"
-    );
+    assert_eq!(count_after_install, 1);
 
-    // Uninstall plugin (FIX: removal now persisted to storage)
+    // Uninstall
     env.as_contract(&smart_account_id, || {
         SmartAccount::uninstall_plugin(&env, plugin_id.clone())
     })
     .unwrap();
 
-    // Verify plugin is uninstalled
     assert!(!env.as_contract(&smart_account_id, || {
         SmartAccount::is_plugin_installed(&env, plugin_id.clone())
     }));
 
-    // Trigger __check_auth again to see if plugin.on_auth still runs
+    // Trigger on_auth again — plugin should NOT run
     let payload2 = BytesN::random(&env);
     let (admin_key2, admin_proof2) = admin.sign(&env, &payload2);
     let auth_payloads2 = SignatureProofs(soroban_sdk::map![&env, (admin_key2, admin_proof2)]);
@@ -259,20 +264,16 @@ fn test_uninstall_plugin_persists_removal() {
     )
     .unwrap();
 
-    // Verify plugin did NOT receive second on_auth call (count should still be 1)
     let count_after_uninstall = env.as_contract(&plugin_id, || DummyPlugin::get_count(&env));
-    assert_eq!(
-        count_after_uninstall, 1,
-        "Plugin should NOT receive on_auth after uninstall"
-    );
+    assert_eq!(count_after_uninstall, 1);
 }
 
 // -----------------------------------------------------------------------------
-// Test: Intentional plugin rejection blocks authorization
+// Test: New-style Err(PluginRejection::Rejected) blocks auth
 // -----------------------------------------------------------------------------
 
 #[test]
-fn test_plugin_intentional_rejection_blocks_auth() {
+fn test_plugin_new_style_rejection_blocks_auth() {
     let env = setup();
     env.mock_all_auths();
 
@@ -291,29 +292,18 @@ fn test_plugin_intentional_rejection_blocks_auth() {
     })
     .unwrap();
 
-    let payload = BytesN::random(&env);
-    let (admin_key, admin_proof) = admin.sign(&env, &payload);
-    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
 
-    let result = env.try_invoke_contract_check_auth::<Error>(
-        &smart_account_id,
-        &payload,
-        auth_payloads.into_val(&env),
-        &vec![&env, get_token_auth_context(&env)],
-    );
-
-    // The rejecting plugin uses panic_with_error! with a SmartAccountError code,
-    // producing Error(Contract, #103). The authorizer sees ScErrorType::Contract
-    // and blocks authorization.
     assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }
 
 // -----------------------------------------------------------------------------
-// Test: Installing more than MAX_PLUGINS plugins fails with MaxPluginsReached
+// Test: Old-style panic_with_error! with custom error still blocks (backwards compat)
 // -----------------------------------------------------------------------------
 
 #[test]
-fn test_max_plugins_limit() {
+fn test_plugin_old_style_rejection_still_blocks() {
     let env = setup();
     env.mock_all_auths();
 
@@ -326,28 +316,55 @@ fn test_max_plugins_limit() {
         ),
     );
 
-    // Install 10 plugins (the maximum allowed)
-    for i in 0..10u32 {
-        let plugin_id = env.register(DummyPlugin, ());
-        env.as_contract(&smart_account_id, || {
-            SmartAccount::install_plugin(&env, plugin_id.clone())
-        })
-        .unwrap_or_else(|e| panic!("Plugin {} install should succeed but got: {:?}", i, e));
-    }
+    let plugin_id = env.register(CustomErrorPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
 
-    // The 11th plugin should fail with MaxPluginsReached
-    let extra_plugin_id = env.register(DummyPlugin, ());
-    let err = env
-        .as_contract(&smart_account_id, || {
-            SmartAccount::install_plugin(&env, extra_plugin_id.clone())
-        })
-        .unwrap_err();
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
 
-    assert_eq!(err, Error::MaxPluginsReached);
+    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }
 
 // -----------------------------------------------------------------------------
-// Test: Bare panic!() in plugin is skipped as technical failure
+// Test: Old void-returning plugin still works (ABI backwards compat)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_old_void_plugin_still_works() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // DummyPlugin returns () — not Result<(), PluginRejection>
+    let plugin_id = env.register(DummyPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+
+    // Void return and Ok(()) produce the same ABI representation.
+    assert!(result.is_ok());
+
+    let count = env.as_contract(&plugin_id, || DummyPlugin::get_count(&env));
+    assert_eq!(count, 1);
+}
+
+// -----------------------------------------------------------------------------
+// Test: Bare panic!() is skipped as technical failure
 // -----------------------------------------------------------------------------
 
 #[test]
@@ -370,61 +387,10 @@ fn test_plugin_bare_panic_skipped() {
     })
     .unwrap();
 
-    let payload = BytesN::random(&env);
-    let (admin_key, admin_proof) = admin.sign(&env, &payload);
-    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
 
-    let result = env.try_invoke_contract_check_auth::<Error>(
-        &smart_account_id,
-        &payload,
-        auth_payloads.into_val(&env),
-        &vec![&env, get_token_auth_context(&env)],
-    );
-
-    // A bare panic! produces Error(Context, InvalidAction) — NOT ScErrorType::Contract.
-    // The authorizer treats this as a technical failure and skips the plugin.
     assert!(result.is_ok());
-}
-
-// -----------------------------------------------------------------------------
-// Test: Plugin with custom #[contracterror] blocks auth
-// -----------------------------------------------------------------------------
-
-#[test]
-fn test_plugin_custom_error_blocks_auth() {
-    let env = setup();
-    env.mock_all_auths();
-
-    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
-    let smart_account_id = env.register(
-        SmartAccount,
-        (
-            vec![&env, admin.into_signer(&env)],
-            Vec::<Address>::new(&env),
-        ),
-    );
-
-    let plugin_id = env.register(CustomErrorPlugin, ());
-    env.as_contract(&smart_account_id, || {
-        SmartAccount::install_plugin(&env, plugin_id.clone())
-    })
-    .unwrap();
-
-    let payload = BytesN::random(&env);
-    let (admin_key, admin_proof) = admin.sign(&env, &payload);
-    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
-
-    let result = env.try_invoke_contract_check_auth::<Error>(
-        &smart_account_id,
-        &payload,
-        auth_payloads.into_val(&env),
-        &vec![&env, get_token_auth_context(&env)],
-    );
-
-    // panic_with_error! with a custom #[contracterror] (code 200, not in
-    // SmartAccountError) produces Error(Contract, #200). The error type is
-    // still ScErrorType::Contract, so it's an intentional rejection.
-    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }
 
 // -----------------------------------------------------------------------------
@@ -445,28 +411,15 @@ fn test_plugin_missing_on_auth_skipped() {
         ),
     );
 
-    // Install a plugin that has on_install but NOT on_auth
     let plugin_id = env.register(NoAuthPlugin, ());
     env.as_contract(&smart_account_id, || {
         SmartAccount::install_plugin(&env, plugin_id.clone())
     })
     .unwrap();
 
-    let payload = BytesN::random(&env);
-    let (admin_key, admin_proof) = admin.sign(&env, &payload);
-    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
 
-    let result = env.try_invoke_contract_check_auth::<Error>(
-        &smart_account_id,
-        &payload,
-        auth_payloads.into_val(&env),
-        &vec![&env, get_token_auth_context(&env)],
-    );
-
-    // Missing on_auth function produces Error(Context, InvalidAction) — NOT
-    // ScErrorType::Contract. The authorizer treats this as a technical failure
-    // and skips the plugin, preventing a misconfigured contract from locking
-    // the wallet.
     assert!(result.is_ok());
 }
 
@@ -488,7 +441,6 @@ fn test_mixed_plugins_crash_does_not_block() {
         ),
     );
 
-    // Install both plugins
     let dummy_id = env.register(DummyPlugin, ());
     env.as_contract(&smart_account_id, || {
         SmartAccount::install_plugin(&env, dummy_id.clone())
@@ -501,21 +453,127 @@ fn test_mixed_plugins_crash_does_not_block() {
     })
     .unwrap();
 
-    let payload = BytesN::random(&env);
-    let (admin_key, admin_proof) = admin.sign(&env, &payload);
-    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
 
-    let result = env.try_invoke_contract_check_auth::<Error>(
-        &smart_account_id,
-        &payload,
-        auth_payloads.into_val(&env),
-        &vec![&env, get_token_auth_context(&env)],
-    );
-
-    // Auth succeeds — the panicking plugin is skipped as a technical failure.
     assert!(result.is_ok());
 
-    // DummyPlugin still received its on_auth call.
     let count = env.as_contract(&dummy_id, || DummyPlugin::get_count(&env));
     assert_eq!(count, 1, "DummyPlugin should still receive on_auth");
+}
+
+// -----------------------------------------------------------------------------
+// Test: Installing more than MAX_PLUGINS plugins fails with MaxPluginsReached
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_max_plugins_limit() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    for i in 0..10u32 {
+        let plugin_id = env.register(DummyPlugin, ());
+        env.as_contract(&smart_account_id, || {
+            SmartAccount::install_plugin(&env, plugin_id.clone())
+        })
+        .unwrap_or_else(|e| panic!("Plugin {} install should succeed but got: {:?}", i, e));
+    }
+
+    let extra_plugin_id = env.register(DummyPlugin, ());
+    let err = env
+        .as_contract(&smart_account_id, || {
+            SmartAccount::install_plugin(&env, extra_plugin_id.clone())
+        })
+        .unwrap_err();
+
+    assert_eq!(err, Error::MaxPluginsReached);
+}
+
+// -----------------------------------------------------------------------------
+// Test: Uninstall bypasses the rejecting plugin (escape hatch)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_uninstall_bypasses_rejecting_plugin() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(RejectingPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    // Normal auth is blocked by the rejecting plugin
+    let token_contexts = vec![&env, get_token_auth_context(&env)];
+    let blocked = check_auth(&env, &smart_account_id, &admin, &token_contexts);
+    assert_eq!(blocked, Err(Ok(Error::PluginOnAuthFailed)));
+
+    // Auth for uninstalling THIS plugin should succeed — the target plugin
+    // is skipped in call_plugins_on_auth.
+    let uninstall_contexts = vec![
+        &env,
+        get_uninstall_plugin_auth_context(&env, &smart_account_id, &plugin_id),
+    ];
+    let allowed = check_auth(&env, &smart_account_id, &admin, &uninstall_contexts);
+    assert!(allowed.is_ok());
+}
+
+// -----------------------------------------------------------------------------
+// Test: Uninstall bypass only skips the target plugin, not others
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_uninstall_bypass_only_skips_target() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Install a rejecting plugin AND a dummy plugin
+    let rejecting_id = env.register(RejectingPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, rejecting_id.clone())
+    })
+    .unwrap();
+
+    let dummy_id = env.register(DummyPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, dummy_id.clone())
+    })
+    .unwrap();
+
+    // Trying to uninstall the DUMMY plugin — the rejecting plugin is NOT
+    // the target, so it still runs and blocks the operation.
+    let uninstall_contexts = vec![
+        &env,
+        get_uninstall_plugin_auth_context(&env, &smart_account_id, &dummy_id),
+    ];
+    let result = check_auth(&env, &smart_account_id, &admin, &uninstall_contexts);
+    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -11,10 +11,7 @@ use crate::{
     account::SmartAccount,
     auth::proof::SignatureProofs,
     error::Error,
-    tests::test_utils::{
-        get_token_auth_context, get_uninstall_plugin_auth_context, setup, Ed25519TestSigner,
-        TestSignerTrait as _,
-    },
+    tests::test_utils::{get_token_auth_context, setup, Ed25519TestSigner, TestSignerTrait as _},
 };
 use smart_account_interfaces::{SignerRole, SmartAccountInterface};
 
@@ -496,84 +493,4 @@ fn test_max_plugins_limit() {
         .unwrap_err();
 
     assert_eq!(err, Error::MaxPluginsReached);
-}
-
-// -----------------------------------------------------------------------------
-// Test: Uninstall bypasses the rejecting plugin (escape hatch)
-// -----------------------------------------------------------------------------
-
-#[test]
-fn test_uninstall_bypasses_rejecting_plugin() {
-    let env = setup();
-    env.mock_all_auths();
-
-    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
-    let smart_account_id = env.register(
-        SmartAccount,
-        (
-            vec![&env, admin.into_signer(&env)],
-            Vec::<Address>::new(&env),
-        ),
-    );
-
-    let plugin_id = env.register(RejectingPlugin, ());
-    env.as_contract(&smart_account_id, || {
-        SmartAccount::install_plugin(&env, plugin_id.clone())
-    })
-    .unwrap();
-
-    // Normal auth is blocked by the rejecting plugin
-    let token_contexts = vec![&env, get_token_auth_context(&env)];
-    let blocked = check_auth(&env, &smart_account_id, &admin, &token_contexts);
-    assert_eq!(blocked, Err(Ok(Error::PluginOnAuthFailed)));
-
-    // Auth for uninstalling THIS plugin should succeed — the target plugin
-    // is skipped in call_plugins_on_auth.
-    let uninstall_contexts = vec![
-        &env,
-        get_uninstall_plugin_auth_context(&env, &smart_account_id, &plugin_id),
-    ];
-    let allowed = check_auth(&env, &smart_account_id, &admin, &uninstall_contexts);
-    assert!(allowed.is_ok());
-}
-
-// -----------------------------------------------------------------------------
-// Test: Uninstall bypass only skips the target plugin, not others
-// -----------------------------------------------------------------------------
-
-#[test]
-fn test_uninstall_bypass_only_skips_target() {
-    let env = setup();
-    env.mock_all_auths();
-
-    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
-    let smart_account_id = env.register(
-        SmartAccount,
-        (
-            vec![&env, admin.into_signer(&env)],
-            Vec::<Address>::new(&env),
-        ),
-    );
-
-    // Install a rejecting plugin AND a dummy plugin
-    let rejecting_id = env.register(RejectingPlugin, ());
-    env.as_contract(&smart_account_id, || {
-        SmartAccount::install_plugin(&env, rejecting_id.clone())
-    })
-    .unwrap();
-
-    let dummy_id = env.register(DummyPlugin, ());
-    env.as_contract(&smart_account_id, || {
-        SmartAccount::install_plugin(&env, dummy_id.clone())
-    })
-    .unwrap();
-
-    // Trying to uninstall the DUMMY plugin — the rejecting plugin is NOT
-    // the target, so it still runs and blocks the operation.
-    let uninstall_contexts = vec![
-        &env,
-        get_uninstall_plugin_auth_context(&env, &smart_account_id, &dummy_id),
-    ];
-    let result = check_auth(&env, &smart_account_id, &admin, &uninstall_contexts);
-    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -68,7 +68,7 @@ mod rejecting_plugin {
         }
 
         pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
-            // This uses panic_with_error! which produces Err(Ok(e)) in try_on_auth,
+            // This uses panic_with_error! which produces a Contract-type error,
             // meaning the plugin intentionally rejected authorization.
             panic_with_error!(env, Error::PluginOnAuthFailed);
         }
@@ -76,6 +76,108 @@ mod rejecting_plugin {
 }
 
 use rejecting_plugin::RejectingPlugin;
+
+// -----------------------------------------------------------------------------
+// Plugin that bare-panics (technical failure, no contract error code)
+// -----------------------------------------------------------------------------
+
+mod panicking_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, Address, Env, Vec};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct PanickingPlugin;
+
+    #[contractimpl]
+    impl PanickingPlugin {
+        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        pub fn on_auth(_env: &Env, _source: Address, _contexts: Vec<Context>) {
+            // Bare panic! produces Error(Context, InvalidAction) — NOT a
+            // contract error. The authorizer skips this as a technical failure.
+            panic!("crashed");
+        }
+    }
+}
+
+use panicking_plugin::PanickingPlugin;
+
+// -----------------------------------------------------------------------------
+// Plugin that rejects with its own #[contracterror] (code outside SmartAccountError)
+// -----------------------------------------------------------------------------
+
+mod custom_error_plugin {
+    use soroban_sdk::{
+        auth::Context, contract, contracterror, contractimpl, panic_with_error, Address, Env, Vec,
+    };
+
+    #[contracterror]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[repr(u32)]
+    pub enum CustomPluginError {
+        Rejected = 200,
+    }
+
+    #[contract]
+    pub struct CustomErrorPlugin;
+
+    #[contractimpl]
+    impl CustomErrorPlugin {
+        pub fn on_install(_env: &Env, _source: Address) {
+            // no-op
+        }
+
+        pub fn on_uninstall(_env: &Env, _source: Address) {
+            // no-op
+        }
+
+        pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
+            // Deliberate rejection using a custom error type whose code (200)
+            // does not match any SmartAccountError variant. This produces
+            // Error(Contract, #200) — still a contract-type error, so the
+            // authorizer must treat it as an intentional rejection.
+            panic_with_error!(env, CustomPluginError::Rejected);
+        }
+    }
+}
+
+use custom_error_plugin::CustomErrorPlugin;
+
+// -----------------------------------------------------------------------------
+// Plugin that has on_install but no on_auth (missing callback)
+// -----------------------------------------------------------------------------
+
+mod no_auth_plugin {
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct NoAuthPlugin;
+
+    #[contractimpl]
+    impl NoAuthPlugin {
+        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+
+        // Deliberately NO on_auth method — simulates a misconfigured or
+        // upgraded contract that lost its on_auth callback.
+    }
+}
+
+use no_auth_plugin::NoAuthPlugin;
 
 // -----------------------------------------------------------------------------
 // Test: Uninstall properly persists removal, plugin no longer receives on_auth
@@ -174,7 +276,6 @@ fn test_plugin_intentional_rejection_blocks_auth() {
     let env = setup();
     env.mock_all_auths();
 
-    // Deploy SmartAccount with one admin signer
     let admin = Ed25519TestSigner::generate(SignerRole::Admin);
     let smart_account_id = env.register(
         SmartAccount,
@@ -184,14 +285,12 @@ fn test_plugin_intentional_rejection_blocks_auth() {
         ),
     );
 
-    // Deploy and install the rejecting plugin
     let plugin_id = env.register(RejectingPlugin, ());
     env.as_contract(&smart_account_id, || {
         SmartAccount::install_plugin(&env, plugin_id.clone())
     })
     .unwrap();
 
-    // Try to authenticate
     let payload = BytesN::random(&env);
     let (admin_key, admin_proof) = admin.sign(&env, &payload);
     let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
@@ -203,9 +302,9 @@ fn test_plugin_intentional_rejection_blocks_auth() {
         &vec![&env, get_token_auth_context(&env)],
     );
 
-    // The rejecting plugin (panic_with_error!) should cause PluginOnAuthFailed,
-    // blocking authorization. This exercises the Err(Ok(_)) branch in
-    // call_plugins_on_auth.
+    // The rejecting plugin uses panic_with_error! with a SmartAccountError code,
+    // producing Error(Contract, #103). The authorizer sees ScErrorType::Contract
+    // and blocks authorization.
     assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
 }
 
@@ -218,7 +317,6 @@ fn test_max_plugins_limit() {
     let env = setup();
     env.mock_all_auths();
 
-    // Deploy SmartAccount with one admin signer
     let admin = Ed25519TestSigner::generate(SignerRole::Admin);
     let smart_account_id = env.register(
         SmartAccount,
@@ -246,4 +344,178 @@ fn test_max_plugins_limit() {
         .unwrap_err();
 
     assert_eq!(err, Error::MaxPluginsReached);
+}
+
+// -----------------------------------------------------------------------------
+// Test: Bare panic!() in plugin is skipped as technical failure
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_plugin_bare_panic_skipped() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(PanickingPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // A bare panic! produces Error(Context, InvalidAction) — NOT ScErrorType::Contract.
+    // The authorizer treats this as a technical failure and skips the plugin.
+    assert!(result.is_ok());
+}
+
+// -----------------------------------------------------------------------------
+// Test: Plugin with custom #[contracterror] blocks auth
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_plugin_custom_error_blocks_auth() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(CustomErrorPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // panic_with_error! with a custom #[contracterror] (code 200, not in
+    // SmartAccountError) produces Error(Contract, #200). The error type is
+    // still ScErrorType::Contract, so it's an intentional rejection.
+    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
+}
+
+// -----------------------------------------------------------------------------
+// Test: Missing on_auth callback is skipped as technical failure
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_plugin_missing_on_auth_skipped() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Install a plugin that has on_install but NOT on_auth
+    let plugin_id = env.register(NoAuthPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // Missing on_auth function produces Error(Context, InvalidAction) — NOT
+    // ScErrorType::Contract. The authorizer treats this as a technical failure
+    // and skips the plugin, preventing a misconfigured contract from locking
+    // the wallet.
+    assert!(result.is_ok());
+}
+
+// -----------------------------------------------------------------------------
+// Test: Crashing plugin does not prevent other plugins from running
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_mixed_plugins_crash_does_not_block() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Install both plugins
+    let dummy_id = env.register(DummyPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, dummy_id.clone())
+    })
+    .unwrap();
+
+    let panicking_id = env.register(PanickingPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, panicking_id.clone())
+    })
+    .unwrap();
+
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // Auth succeeds — the panicking plugin is skipped as a technical failure.
+    assert!(result.is_ok());
+
+    // DummyPlugin still received its on_auth call.
+    let count = env.as_contract(&dummy_id, || DummyPlugin::get_count(&env));
+    assert_eq!(count, 1, "DummyPlugin should still receive on_auth");
 }

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -494,3 +494,414 @@ fn test_max_plugins_limit() {
 
     assert_eq!(err, Error::MaxPluginsReached);
 }
+
+// =============================================================================
+// ABI backwards compatibility — exhaustive tests
+//
+// These tests verify that every old-style plugin pattern continues to work
+// after the on_auth return type changed from () to Result<(), PluginRejection>.
+// =============================================================================
+
+// -- Additional old-style plugin variants ------------------------------------
+
+/// Old-style plugin that does storage writes, event emission, and returns void.
+/// Simulates a "real" plugin doing actual work.
+mod storage_event_plugin {
+    use soroban_sdk::{
+        auth::Context, contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+        Vec,
+    };
+
+    const KEY: Symbol = symbol_short!("se_cnt");
+
+    #[contracttype]
+    #[derive(Clone, Debug)]
+    pub struct PluginAuthEvent {
+        pub source: Address,
+        pub count: u32,
+    }
+
+    #[contract]
+    pub struct StorageEventPlugin;
+
+    #[contractimpl]
+    impl StorageEventPlugin {
+        pub fn on_install(_env: &Env, _source: Address) {}
+        pub fn on_uninstall(_env: &Env, _source: Address) {}
+        pub fn on_auth(env: &Env, source: Address, _contexts: Vec<Context>) {
+            let count: u32 = env.storage().instance().get(&KEY).unwrap_or(0);
+            let new_count = count + 1;
+            env.storage().instance().set(&KEY, &new_count);
+            env.events().publish(
+                (symbol_short!("AUTH"),),
+                PluginAuthEvent {
+                    source,
+                    count: new_count,
+                },
+            );
+        }
+        pub fn get_count(env: &Env) -> u32 {
+            env.storage().instance().get(&KEY).unwrap_or(0)
+        }
+    }
+}
+
+use storage_event_plugin::StorageEventPlugin;
+
+/// Old-style plugin that returns Result<(), SmartAccountError> with Ok(()).
+/// Some plugins may have adopted Result return early — this must still work.
+mod result_ok_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, Address, Env, Vec};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct ResultOkPlugin;
+
+    #[contractimpl]
+    impl ResultOkPlugin {
+        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+        pub fn on_auth(_env: &Env, _source: Address, _contexts: Vec<Context>) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+}
+
+use result_ok_plugin::ResultOkPlugin;
+
+/// Old-style plugin that returns Result<(), SmartAccountError> with Err.
+/// Tests that a plugin rejecting via Result::Err with a SmartAccountError
+/// is correctly classified as an intentional rejection.
+mod result_err_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, Address, Env, Vec};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct ResultErrPlugin;
+
+    #[contractimpl]
+    impl ResultErrPlugin {
+        pub fn on_install(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+        pub fn on_uninstall(_env: &Env, _source: Address) -> Result<(), Error> {
+            Ok(())
+        }
+        pub fn on_auth(_env: &Env, _source: Address, _contexts: Vec<Context>) -> Result<(), Error> {
+            Err(Error::PluginOnAuthFailed)
+        }
+    }
+}
+
+use result_err_plugin::ResultErrPlugin;
+
+/// Old-style plugin that uses panic_with_error! with a SmartAccountError code
+/// (the pattern used by the original RejectingPlugin in pre-#115 code).
+mod old_panic_with_known_error_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, panic_with_error, Address, Env, Vec};
+
+    use crate::error::Error;
+
+    #[contract]
+    pub struct OldPanicKnownErrorPlugin;
+
+    #[contractimpl]
+    impl OldPanicKnownErrorPlugin {
+        pub fn on_install(_env: &Env, _source: Address) {}
+        pub fn on_uninstall(_env: &Env, _source: Address) {}
+        pub fn on_auth(env: &Env, _source: Address, _contexts: Vec<Context>) {
+            panic_with_error!(env, Error::PluginOnAuthFailed);
+        }
+    }
+}
+
+use old_panic_with_known_error_plugin::OldPanicKnownErrorPlugin;
+
+// -- Direct try_on_auth result verification ----------------------------------
+
+/// Calls try_on_auth directly on each plugin type and asserts the exact
+/// Result variant. This is the most granular verification that the ABI
+/// change doesn't alter the observable error classification.
+#[test]
+fn test_try_on_auth_result_variants() {
+    use smart_account_interfaces::SmartAccountPluginClient;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::InvokeError;
+
+    let env = setup();
+    env.mock_all_auths();
+
+    let source = soroban_sdk::Address::generate(&env);
+    let contexts = Vec::new(&env);
+
+    // 1. DummyPlugin (void return, succeeds) → Ok(Ok(()))
+    let id = env.register(DummyPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Ok(Ok(()))),
+        "void-returning success should be Ok(Ok(())): {:?}",
+        res
+    );
+
+    // 2. StorageEventPlugin (void return, does real work) → Ok(Ok(()))
+    let id = env.register(StorageEventPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Ok(Ok(()))),
+        "void-returning plugin with storage+events should be Ok(Ok(())): {:?}",
+        res
+    );
+    // Verify the plugin actually executed (side-effect check)
+    let count = env.as_contract(&id, || StorageEventPlugin::get_count(&env));
+    assert_eq!(count, 1, "StorageEventPlugin should have executed its body");
+
+    // 3. ResultOkPlugin (returns Result<(), Error> with Ok(())) → Ok(Ok(()))
+    let id = env.register(ResultOkPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Ok(Ok(()))),
+        "Result::Ok(()) should be Ok(Ok(())): {:?}",
+        res
+    );
+
+    // 4. RejectingPlugin (new-style Err(PluginRejection)) → Err(Ok(_))
+    let id = env.register(RejectingPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Ok(_))),
+        "new-style Err(PluginRejection) should be Err(Ok(_)): {:?}",
+        res
+    );
+
+    // 5. ResultErrPlugin (Result::Err(SmartAccountError)) → Err(Err(Contract(_)))
+    //    SmartAccountError code doesn't match PluginRejection, so TryFrom fails
+    //    and it becomes InvokeError::Contract(code).
+    let id = env.register(ResultErrPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Err(InvokeError::Contract(_)))),
+        "Result::Err(SmartAccountError) should be Err(Err(Contract(_))): {:?}",
+        res
+    );
+
+    // 6. OldPanicKnownErrorPlugin (panic_with_error! with SmartAccountError)
+    //    → Err(Err(Contract(_))) because the SmartAccountError code doesn't match
+    //    PluginRejection variants.
+    let id = env.register(OldPanicKnownErrorPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Err(InvokeError::Contract(_)))),
+        "panic_with_error!(SmartAccountError) should be Err(Err(Contract(_))): {:?}",
+        res
+    );
+
+    // 7. CustomErrorPlugin (panic_with_error! with custom code 200)
+    //    → Err(Err(Contract(200)))
+    let id = env.register(CustomErrorPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Err(InvokeError::Contract(200)))),
+        "panic_with_error!(CustomPluginError::Rejected=200) should be Err(Err(Contract(200))): {:?}",
+        res
+    );
+
+    // 8. PanickingPlugin (bare panic!) → Err(Err(Abort))
+    let id = env.register(PanickingPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Err(InvokeError::Abort))),
+        "bare panic! should be Err(Err(Abort)): {:?}",
+        res
+    );
+
+    // 9. NoAuthPlugin (missing on_auth) → Err(Err(Abort))
+    let id = env.register(NoAuthPlugin, ());
+    let res = SmartAccountPluginClient::new(&env, &id).try_on_auth(&source, &contexts);
+    assert!(
+        matches!(res, Err(Err(InvokeError::Abort))),
+        "missing on_auth should be Err(Err(Abort)): {:?}",
+        res
+    );
+}
+
+// -- End-to-end auth tests for each old-style plugin -------------------------
+
+#[test]
+fn test_old_void_plugin_with_storage_and_events_works() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(StorageEventPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert!(
+        result.is_ok(),
+        "void plugin with storage+events should pass auth"
+    );
+
+    // Verify the plugin's side effects actually ran
+    let count = env.as_contract(&plugin_id, || StorageEventPlugin::get_count(&env));
+    assert_eq!(count, 1, "plugin should have incremented counter");
+
+    // Run auth again to verify counter increments
+    let result2 = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert!(result2.is_ok());
+    let count2 = env.as_contract(&plugin_id, || StorageEventPlugin::get_count(&env));
+    assert_eq!(count2, 2, "plugin should have incremented counter again");
+}
+
+#[test]
+fn test_old_result_ok_plugin_works() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(ResultOkPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert!(
+        result.is_ok(),
+        "plugin returning Result::Ok(()) should pass auth"
+    );
+}
+
+#[test]
+fn test_old_result_err_plugin_blocks_auth() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(ResultErrPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert_eq!(
+        result,
+        Err(Ok(Error::PluginOnAuthFailed)),
+        "plugin returning Result::Err should block auth"
+    );
+}
+
+#[test]
+fn test_old_panic_with_known_error_blocks_auth() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // This is the exact pattern used by the old RejectingPlugin before PR #115:
+    // panic_with_error!(env, Error::PluginOnAuthFailed)
+    let plugin_id = env.register(OldPanicKnownErrorPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert_eq!(
+        result,
+        Err(Ok(Error::PluginOnAuthFailed)),
+        "old-style panic_with_error!(SmartAccountError) should still block auth"
+    );
+}
+
+/// Mixed scenario: one old-style void plugin + one new-style Result plugin,
+/// both approving. Verifies both can coexist.
+#[test]
+fn test_mixed_old_and_new_plugins_both_approve() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    // Old-style void plugin
+    let dummy_id = env.register(DummyPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, dummy_id.clone())
+    })
+    .unwrap();
+
+    // Old-style Result::Ok plugin
+    let result_ok_id = env.register(ResultOkPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, result_ok_id.clone())
+    })
+    .unwrap();
+
+    // Old-style void plugin with side effects
+    let storage_id = env.register(StorageEventPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, storage_id.clone())
+    })
+    .unwrap();
+
+    let contexts = vec![&env, get_token_auth_context(&env)];
+    let result = check_auth(&env, &smart_account_id, &admin, &contexts);
+    assert!(result.is_ok(), "all three approving plugins should pass");
+
+    // Verify both side-effect plugins ran
+    let dummy_count = env.as_contract(&dummy_id, || DummyPlugin::get_count(&env));
+    assert_eq!(dummy_count, 1);
+    let storage_count = env.as_contract(&storage_id, || StorageEventPlugin::get_count(&env));
+    assert_eq!(storage_count, 1);
+}

--- a/contracts/smart-account/src/tests/test_utils.rs
+++ b/contracts/smart-account/src/tests/test_utils.rs
@@ -35,18 +35,6 @@ pub fn get_token_auth_context(e: &Env) -> Context {
     })
 }
 
-pub fn get_uninstall_plugin_auth_context(
-    e: &Env,
-    contract_id: &Address,
-    plugin: &Address,
-) -> Context {
-    Context::Contract(ContractContext {
-        contract: contract_id.clone(),
-        fn_name: "uninstall_plugin".into_val(e),
-        args: (plugin.clone(),).into_val(e),
-    })
-}
-
 pub fn get_update_signer_auth_context(e: &Env, contract_id: &Address, signer: Signer) -> Context {
     Context::Contract(ContractContext {
         contract: contract_id.clone(),

--- a/contracts/smart-account/src/tests/test_utils.rs
+++ b/contracts/smart-account/src/tests/test_utils.rs
@@ -35,6 +35,18 @@ pub fn get_token_auth_context(e: &Env) -> Context {
     })
 }
 
+pub fn get_uninstall_plugin_auth_context(
+    e: &Env,
+    contract_id: &Address,
+    plugin: &Address,
+) -> Context {
+    Context::Contract(ContractContext {
+        contract: contract_id.clone(),
+        fn_name: "uninstall_plugin".into_val(e),
+        args: (plugin.clone(),).into_val(e),
+    })
+}
+
 pub fn get_update_signer_auth_context(e: &Env, contract_id: &Address, signer: Signer) -> Context {
     Context::Contract(ContractContext {
         contract: contract_id.clone(),


### PR DESCRIPTION
## Summary

Fixes plugin error classification in `call_plugins_on_auth` by changing the `on_auth` interface and replacing the dead-code match arms.

### Problems solved

1. **Dead-code match arms** — `on_auth` returned `()`, so the `#[contractclient]` macro set `E = soroban_sdk::Error`. Since `TryFrom<Error> for Error` is the identity, all errors landed in `Err(Ok(_))` and the `InvokeError::Abort` / `InvokeError::Contract` arms were unreachable.

2. **Custom error rejections ignored** — A plugin using `panic_with_error!` with its own `#[contracterror]` type had its rejection silently skipped.

### How it's fixed

**`on_auth` now returns `Result<(), PluginRejection>`** — ABI backwards compatible because `Ok(())` produces the same wire format (Void) as the old `()` return. Old deployed plugins continue working without recompilation.

With `E = PluginRejection` (a real `#[contracterror]`), all five match arms are now reachable:

| Arm | Meaning | Action |
|-----|---------|--------|
| `Ok(Ok(_))` | Approved (new or old-style void return) | Continue |
| `Ok(Err(_))` | ABI mismatch | Skip |
| `Err(Ok(_))` | New-style `Err(PluginRejection::Rejected)` | **Block auth** |
| `Err(Err(Contract(_)))` | Old-style `panic_with_error!` (backwards compat) | **Block auth** |
| `Err(Err(Abort))` | Bare panic, missing function, host trap | Skip |

## Test plan

14 plugin tests covering every old-style plugin pattern:

| Test | Plugin style | Assertion |
|------|-------------|-----------|
| `test_try_on_auth_result_variants` | All 9 plugin types via direct `try_on_auth` | Exact `Result` variant for each |
| `test_old_void_plugin_still_works` | `()` return | Auth passes |
| `test_old_void_plugin_with_storage_and_events_works` | `()` with storage writes + events | Auth passes, side effects run |
| `test_old_result_ok_plugin_works` | `Result<(), Error>` returning `Ok` | Auth passes |
| `test_old_result_err_plugin_blocks_auth` | `Result<(), Error>` returning `Err` | Auth blocked |
| `test_old_panic_with_known_error_blocks_auth` | `panic_with_error!(SmartAccountError)` | Auth blocked |
| `test_plugin_old_style_rejection_still_blocks` | `panic_with_error!(CustomError)` code 200 | Auth blocked |
| `test_plugin_new_style_rejection_blocks_auth` | `Err(PluginRejection::Rejected)` | Auth blocked |
| `test_plugin_bare_panic_skipped` | `panic!("crashed")` | Auth passes (skipped) |
| `test_plugin_missing_on_auth_skipped` | No `on_auth` function | Auth passes (skipped) |
| `test_mixed_plugins_crash_does_not_block` | DummyPlugin + PanickingPlugin | Auth passes, Dummy runs |
| `test_mixed_old_and_new_plugins_both_approve` | 3 approving plugins (void + Result + storage) | All pass, side effects run |
| `test_uninstall_plugin_persists_removal` | Install/uninstall lifecycle | Counter stops after uninstall |
| `test_max_plugins_limit` | 11 plugins | 11th fails with MaxPluginsReached |

- [x] `cargo test --workspace` — all 167 tests pass
- [x] `cargo fmt --check` — clean