### PR TITLE
fix: guard upgrade() against overlapping migrations

### DIFF
--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -64,6 +64,11 @@ impl SmartAccountUpgradeableMigratableInternal for SmartAccount {
 impl SmartAccountUpgradeableMigratable for SmartAccount {
     fn upgrade(e: &Env, new_wasm_hash: BytesN<32>) {
         Self::_require_auth_upgrade(e);
+        // Refuse to start a new upgrade while a previous one is still
+        // pending its migrate() call. Without this guard, a second
+        // upgrade() would silently swap WASM again before the first
+        // migration ran, orphaning the migration chain.
+        upgradeable::ensure_no_pending_migration(e);
         upgradeable::enable_migration(e);
         e.events().publish(
             (Symbol::new(e, "UPGRADE_STARTED"),),

--- a/contracts/smart-account/src/tests/upgrade_test.rs
+++ b/contracts/smart-account/src/tests/upgrade_test.rs
@@ -1048,3 +1048,78 @@ fn test_auth_standard_cannot_authorize_migrate_after_migration() {
         Ok(err) => assert_eq!(err, Error::InsufficientPermissions),
     }
 }
+
+// ============================================================================
+// Test: upgrade() rejects a second call while a previous migration is pending
+//
+// Regression guard for the missing `ensure_no_pending_migration` check in
+// account.rs::upgrade. Without the guard, an admin could swap WASM twice
+// without running migrate() in between, orphaning the migration chain.
+//
+// Drives the *current* source's upgrade via `env.as_contract` so the test
+// doesn't depend on the frozen testdata/smart_account_v2.wasm artifact.
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1110)")]
+fn test_upgrade_rejected_when_migration_pending() {
+    use crate::account::SmartAccount;
+    use crate::tests::test_utils::{Ed25519TestSigner, TestSignerTrait as _};
+    use smart_account_interfaces::SignerRole;
+    use upgradeable::SmartAccountUpgradeableMigratable as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin).into_signer(&env);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            soroban_sdk::vec![&env, admin],
+            soroban_sdk::Vec::<soroban_sdk::Address>::new(&env),
+        ),
+    );
+
+    // Simulate a prior upgrade that left MIGRATING=true (no migrate run).
+    env.as_contract(&contract_id, || {
+        upgradeable::enable_migration(&env);
+    });
+
+    // Second upgrade must now panic with MigrationAlreadyPending (#1110).
+    env.as_contract(&contract_id, || {
+        SmartAccount::upgrade(&env, BytesN::random(&env));
+    });
+}
+
+// ============================================================================
+// Test: upgrade() is allowed again after migrate() completes
+// ============================================================================
+
+#[test]
+fn test_upgrade_allowed_after_migrate_completes() {
+    use crate::account::SmartAccount;
+    use crate::tests::test_utils::{Ed25519TestSigner, TestSignerTrait as _};
+    use smart_account_interfaces::SignerRole;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin).into_signer(&env);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            soroban_sdk::vec![&env, admin],
+            soroban_sdk::Vec::<soroban_sdk::Address>::new(&env),
+        ),
+    );
+
+    // Walk the full upgrade lifecycle via the helpers used by
+    // account.rs::upgrade and account.rs::migrate.
+    env.as_contract(&contract_id, || {
+        upgradeable::enable_migration(&env);
+        // (skipping the actual WASM swap — we are only verifying the guard)
+        upgradeable::complete_migration(&env);
+        // After complete_migration, the next upgrade must NOT panic on the guard.
+        upgradeable::ensure_no_pending_migration(&env);
+    });
+}


### PR DESCRIPTION
## Summary

`account.rs::upgrade` overrides the default `SmartAccountUpgradeableMigratable::upgrade` impl in the `upgradeable` crate but drops a one-liner from it: the `ensure_no_pending_migration(e)` guard.

Without the guard, an admin who issues a second `upgrade()` before calling `migrate()` will silently swap WASM again — the first upgrade's pending migration is orphaned. Depending on the next `migrate()` call, this either runs the wrong migration logic against the wrong storage layout, or fails with `MigrationVersionMismatch` and leaves `MIGRATING = true` permanently.

The `upgradeable` crate already ships a regression test (`upgradeable/src/test.rs::test_upgrade_rejected_when_migration_pending`) asserting that this case must panic with `MigrationAlreadyPending` (#1110). The smart account had simply opted out by overriding the trait method.

This PR is the missing one-liner.

```rust
fn upgrade(e: &Env, new_wasm_hash: BytesN<32>) {
    Self::_require_auth_upgrade(e);
    upgradeable::ensure_no_pending_migration(e);   // <-- added
    upgradeable::enable_migration(e);
    ...
}
```

## Test plan

- [x] `test_upgrade_rejected_when_migration_pending` — registers a SmartAccount, simulates a prior incomplete upgrade by calling `enable_migration` directly via `env.as_contract`, then invokes `SmartAccount::upgrade` and expects panic `#1110`.
- [x] `test_upgrade_allowed_after_migrate_completes` — same setup, but completes the migration via `complete_migration` first, then asserts the guard does not panic.
- [x] All existing upgrade tests pass (19 → 21 in `tests::upgrade_test`).

## Why the test doesn't go through the v1→v2 binary path

The existing `test_migrate_cannot_run_twice` exercises the frozen `testdata/smart_account_v2.wasm`, so the assertion runs against the *old* v2 binary. To test the fix without rebuilding the testdata artifact, the new tests drive the *current* source's `upgrade` directly via `env.as_contract` and call `upgradeable::enable_migration` to seed the precondition. This keeps the fix self-contained — no testdata rebuild required for CI to assert the regression is closed.

## Risk

Trivial. The guard already exists in the `upgradeable` crate and is unit-tested there. This PR re-attaches it to the smart account's overridden `upgrade`. Existing accounts with `MIGRATING = false` (the normal post-migrate state) are unaffected.