### PR TITLE
fix: enforce WebAuthn assertion type and User-Present flag

### DIFF
--- a/contracts/smart-account/src/auth/signers/webauthn.rs
+++ b/contracts/smart-account/src/auth/signers/webauthn.rs
@@ -5,10 +5,24 @@ use base64ct::{Base64UrlUnpadded, Encoding};
 use smart_account_interfaces::WebauthnSigner;
 use soroban_sdk::{crypto::Hash, Env};
 
+/// WebAuthn assertion `clientDataJSON` fields the verifier inspects.
+///
+/// Per W3C WebAuthn §7.2.11, an authentication assertion MUST set
+/// `type` to `"webauthn.get"`. We pin both `type` and `challenge`; other
+/// fields (`origin`, `crossOrigin`) are intentionally ignored here —
+/// `origin` enforcement requires per-signer expected-origin storage and
+/// is tracked for a future schema change.
 #[derive(serde::Deserialize)]
 struct ClientDataJson<'a> {
+    #[serde(rename = "type")]
+    ty: &'a str,
     challenge: &'a str,
 }
+
+const WEBAUTHN_GET_TYPE: &str = "webauthn.get";
+
+/// Authenticator-data flag bits (WebAuthn §6.1).
+const FLAG_USER_PRESENT: u8 = 0x01;
 
 impl SignatureVerifier for WebauthnSigner {
     fn verify(
@@ -32,6 +46,13 @@ impl SignatureVerifier for WebauthnSigner {
                     return Err(Error::InvalidWebauthnClientDataJson);
                 }
 
+                // The User-Present (UP) bit MUST be set for a valid assertion.
+                // `authenticator_data[32]` is the flags byte.
+                let flags = authenticator_data.get(32).unwrap_or(0);
+                if flags & FLAG_USER_PRESENT == 0 {
+                    return Err(Error::InvalidWebauthnClientDataJson);
+                }
+
                 if client_data_json.len() > 1024 {
                     return Err(Error::InvalidWebauthnClientDataJson);
                 }
@@ -40,6 +61,13 @@ impl SignatureVerifier for WebauthnSigner {
                 let (parsed_client_data, _): (ClientDataJson, _) =
                     serde_json_core::de::from_slice(client_data_json_buf.as_slice())
                         .map_err(|_| Error::InvalidWebauthnClientDataJson)?;
+
+                // Reject anything that isn't a WebAuthn authentication ceremony
+                // — this prevents a webauthn.create signature from being replayed
+                // as a webauthn.get assertion.
+                if parsed_client_data.ty != WEBAUTHN_GET_TYPE {
+                    return Err(Error::InvalidWebauthnClientDataJson);
+                }
 
                 let mut buf = [0u8; 64];
                 let expected_challenge =

--- a/contracts/smart-account/src/tests/test_utils.rs
+++ b/contracts/smart-account/src/tests/test_utils.rs
@@ -246,6 +246,99 @@ impl WebauthnTestSigner {
         let proof = self.build_webauthn_proof(env, payload, Some(&wrong));
         (signer_key, proof)
     }
+
+    /// Sign with `type: "webauthn.create"` (registration ceremony) instead of
+    /// `"webauthn.get"` — for verifying that the assertion verifier rejects
+    /// non-authentication ceremonies.
+    pub fn sign_with_wrong_type(
+        &self,
+        env: &Env,
+        payload: &BytesN<32>,
+    ) -> (SignerKey, SignerProof) {
+        let signer_key = SignerKey::Webauthn(Bytes::from_array(env, &self.key_id));
+        let proof = self.build_webauthn_proof_with_type(env, payload, "webauthn.create");
+        (signer_key, proof)
+    }
+
+    /// Sign with the User-Present (UP) flag bit cleared in `authenticator_data`.
+    /// Used to verify the verifier rejects assertions without user presence.
+    pub fn sign_without_user_present(
+        &self,
+        env: &Env,
+        payload: &BytesN<32>,
+    ) -> (SignerKey, SignerProof) {
+        let signer_key = SignerKey::Webauthn(Bytes::from_array(env, &self.key_id));
+        let proof = self.build_webauthn_proof_with_flags(env, payload, 0x00);
+        (signer_key, proof)
+    }
+
+    fn build_webauthn_proof_with_type(
+        &self,
+        env: &Env,
+        payload: &BytesN<32>,
+        ty: &str,
+    ) -> SignerProof {
+        let challenge = Base64UrlUnpadded::encode_string(&payload.to_array());
+        let client_data = WebauthnClientData {
+            ty,
+            challenge: &challenge,
+            origin: "https://example.com",
+            cross_origin: None,
+        };
+        let client_data_json = serde_json::to_vec(&client_data).unwrap();
+        let authenticator_data = Self::build_authenticator_data();
+        let client_data_hash = Sha256::digest(&client_data_json);
+        let mut signed_data = authenticator_data.clone();
+        signed_data.extend_from_slice(&client_data_hash);
+        let signature: P256Signature =
+            p256::ecdsa::signature::Signer::sign(&self.signing_key, &signed_data);
+        let normalized = normalize_signature(&signature);
+        SignerProof::Webauthn(WebauthnSignature {
+            authenticator_data: Bytes::from_slice(env, &authenticator_data),
+            client_data_json: Bytes::from_slice(env, &client_data_json),
+            signature: BytesN::from_array(
+                env,
+                normalized.to_bytes().as_slice().try_into().unwrap(),
+            ),
+        })
+    }
+
+    fn build_webauthn_proof_with_flags(
+        &self,
+        env: &Env,
+        payload: &BytesN<32>,
+        flags: u8,
+    ) -> SignerProof {
+        let challenge = Base64UrlUnpadded::encode_string(&payload.to_array());
+        let client_data = WebauthnClientData {
+            ty: "webauthn.get",
+            challenge: &challenge,
+            origin: "https://example.com",
+            cross_origin: None,
+        };
+        let client_data_json = serde_json::to_vec(&client_data).unwrap();
+
+        // Build authenticator_data with the supplied flags byte.
+        let mut authenticator_data = Vec::new();
+        authenticator_data.extend_from_slice(&Sha256::digest(b"example.com"));
+        authenticator_data.push(flags);
+        authenticator_data.extend_from_slice(&42u32.to_be_bytes());
+
+        let client_data_hash = Sha256::digest(&client_data_json);
+        let mut signed_data = authenticator_data.clone();
+        signed_data.extend_from_slice(&client_data_hash);
+        let signature: P256Signature =
+            p256::ecdsa::signature::Signer::sign(&self.signing_key, &signed_data);
+        let normalized = normalize_signature(&signature);
+        SignerProof::Webauthn(WebauthnSignature {
+            authenticator_data: Bytes::from_slice(env, &authenticator_data),
+            client_data_json: Bytes::from_slice(env, &client_data_json),
+            signature: BytesN::from_array(
+                env,
+                normalized.to_bytes().as_slice().try_into().unwrap(),
+            ),
+        })
+    }
 }
 
 impl TestSignerTrait for WebauthnTestSigner {

--- a/contracts/smart-account/src/tests/webauthn_signer_test.rs
+++ b/contracts/smart-account/src/tests/webauthn_signer_test.rs
@@ -92,3 +92,75 @@ fn test_webauthn_end_to_end_auth() {
     )
     .unwrap();
 }
+
+// ============================================================================
+// Spec compliance: WebAuthn assertions must use type "webauthn.get" (W3C §7.2.11)
+// ============================================================================
+
+#[test]
+fn test_webauthn_wrong_type_rejected() {
+    let env = setup();
+    let signer = WebauthnTestSigner::generate(SignerRole::Admin);
+
+    let payload_hash = env.crypto().sha256(&Bytes::from_array(&env, &[0xAB; 32]));
+    let (_, wrong_type_proof) = signer.sign_with_wrong_type(&env, &payload_hash.to_bytes());
+
+    let result = signer
+        .into_signer(&env)
+        .verify(&env, &payload_hash, &wrong_type_proof);
+    assert!(matches!(
+        result,
+        Err(Error::InvalidWebauthnClientDataJson)
+    ));
+}
+
+#[test]
+fn test_webauthn_wrong_type_rejected_end_to_end() {
+    let env = setup();
+    let test_signer = WebauthnTestSigner::generate(SignerRole::Admin);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, test_signer.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let payload = BytesN::random(&env);
+    let (signer_key, proof) = test_signer.sign_with_wrong_type(&env, &payload);
+    let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
+
+    match env
+        .try_invoke_contract_check_auth::<Error>(
+            &contract_id,
+            &payload,
+            auth_payloads.into_val(&env),
+            &vec![&env, get_token_auth_context(&env)],
+        )
+        .unwrap_err()
+    {
+        Ok(err) => assert_eq!(err, Error::InvalidWebauthnClientDataJson),
+        Err(other) => panic!("unexpected host error {:?}", other),
+    }
+}
+
+// ============================================================================
+// Spec compliance: User-Present (UP) flag must be set (W3C §6.1)
+// ============================================================================
+
+#[test]
+fn test_webauthn_missing_user_present_flag_rejected() {
+    let env = setup();
+    let signer = WebauthnTestSigner::generate(SignerRole::Admin);
+
+    let payload_hash = env.crypto().sha256(&Bytes::from_array(&env, &[0xAB; 32]));
+    let (_, proof) = signer.sign_without_user_present(&env, &payload_hash.to_bytes());
+
+    let result = signer
+        .into_signer(&env)
+        .verify(&env, &payload_hash, &proof);
+    assert!(matches!(
+        result,
+        Err(Error::InvalidWebauthnClientDataJson)
+    ));
+}


### PR DESCRIPTION
## Summary

The WebAuthn verifier (`auth/signers/webauthn.rs`) was missing two spec-mandated checks:

| Spec | Check | Fix |
|------|-------|-----|
| WebAuthn §7.2.11 | `clientDataJSON.type == "webauthn.get"` | Add `ty` field to `ClientDataJson` and reject anything other than `"webauthn.get"` |
| WebAuthn §6.1 | User-Present (UP) bit set in `authenticator_data` flags | Reject if `authenticator_data[32] & 0x01 == 0` |

Both checks are cheap (one string compare, one bit test) and live in the existing fail-fast block ahead of the ECDSA verification.

## Why this matters

**Type check:** A signature produced during a `navigator.credentials.create()` ceremony is signed over a `clientDataJSON` whose `type` is `"webauthn.create"`. Without the type check, that signature could be replayed against this contract if its challenge happened to match a Stellar transaction hash. The attacker scenario requires luring the victim into a registration ceremony on a hostile origin, but the defense is essentially free and removes a class of cross-ceremony replay risk that the WebAuthn spec specifically calls out.

**UP flag:** Modern authenticators almost always set the UP bit, but the spec is clear that the verifier must require it — without enforcement the contract trusts whatever the authenticator reports, including assertions that occurred without any user interaction.

## Test plan

- [x] `test_webauthn_wrong_type_rejected` — assertion with `type: "webauthn.create"` returns `Err(InvalidWebauthnClientDataJson)`.
- [x] `test_webauthn_wrong_type_rejected_end_to_end` — same, through `try_invoke_contract_check_auth`.
- [x] `test_webauthn_missing_user_present_flag_rejected` — `authenticator_data[32] = 0x00` returns `Err(InvalidWebauthnClientDataJson)`.
- [x] All existing webauthn tests still pass — the existing `test_utils::WebauthnTestSigner` already produces `type: "webauthn.get"` and `flags: 0x01` so no regression.
- [x] Full suite: 129 passed, 0 failed (3 new tests, no regressions).

## Out of scope

- `clientDataJSON.origin` and `authenticator_data` `rpIdHash` enforcement. Both require a per-signer expected value (origin string / RP ID), which means a `WebauthnSigner` schema change and migration. Tracked for a future v3 schema bump.
- Counter monotonicity. WebAuthn lets the RP enforce it; in our model each transaction signs a fresh challenge so replay isn't possible without a counter, but spec compliance would add it. Tracked separately.

## Backwards compatibility

Real-world authenticators producing `type: "webauthn.get"` with UP set (overwhelming majority) are unaffected. Any client previously relying on the lax verification behavior — sending non-`"webauthn.get"` ceremonies or zero flags — will now be rejected. A grep across known integrations is suggested before rollout.