### PR TITLE
docs: correct plugin failure-classification comment in authorizer

### DIFF
--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -91,10 +91,23 @@ impl Authorizer {
         {
             let res = SmartAccountPluginClient::new(env, &plugin)
                 .try_on_auth(&env.current_contract_address(), auth_contexts);
+            // Plugin-result classification (Soroban 22 try_* semantics):
+            //   Ok(Ok(_))   — plugin returned normally                   → continue
+            //   Ok(Err(_))  — return-value ABI decode failure            → SKIP (fail-open)
+            //   Err(Ok(_))  — contracterror OR panic!/unwrap/unreachable → REJECT (fail-closed)
+            //   Err(Err(_)) — host trap (archival, budget, missing code) → SKIP (fail-open)
+            //
+            // Note: any `panic!` from the plugin — including an unwrap that
+            // fires or an arithmetic overflow — lands in the Err(Ok(_))
+            // branch and blocks auth. Only environmental host traps
+            // (storage archival, budget exhaustion, stack overflow,
+            // contract-not-found) reach Err(Err(_)) and are silently
+            // skipped. Plugins that want to stay enforceable should
+            // manage their own TTL and avoid unbounded work.
             match res {
                 // Plugin executed successfully
                 Ok(Ok(_)) => {}
-                // Plugin return value conversion failure (ABI mismatch)
+                // Plugin return value ABI decode failure
                 // Treat as technical failure: log and continue
                 Ok(Err(_)) => {
                     env.events().publish(
@@ -105,7 +118,8 @@ impl Authorizer {
                         },
                     );
                 }
-                // Plugin intentionally rejected (contracterror / panic_with_error!)
+                // Plugin intentionally rejected (contracterror) or panicked
+                // (panic!, panic_with_error!, unwrap, arithmetic overflow, etc.)
                 Err(Ok(_)) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
@@ -116,8 +130,10 @@ impl Authorizer {
                     );
                     return Err(Error::PluginOnAuthFailed);
                 }
-                // Plugin had a technical failure (panic!, host trap, TTL expiry)
-                // Non-blocking: log and continue to next plugin
+                // Host-level failure: storage archival, budget exhaustion,
+                // contract not found, stack overflow. Non-blocking: log
+                // and continue to next plugin so an unreachable plugin
+                // cannot brick the account.
                 Err(Err(_)) => {
                     env.events().publish(
                         (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),

--- a/contracts/smart-account/src/tests/plugin_test.rs
+++ b/contracts/smart-account/src/tests/plugin_test.rs
@@ -247,3 +247,62 @@ fn test_max_plugins_limit() {
 
     assert_eq!(err, Error::MaxPluginsReached);
 }
+
+// -----------------------------------------------------------------------------
+// Plugin that crashes via plain `panic!` — Soroban 22 classifies this as
+// Err(Ok(_)), i.e. fail-closed. The authorizer comment previously grouped
+// `panic!` with host traps in the fail-open branch, which was inaccurate.
+// This test pins the actual behaviour so future refactors cannot regress it.
+// -----------------------------------------------------------------------------
+
+mod panicking_plugin {
+    use soroban_sdk::{auth::Context, contract, contractimpl, Address, Env, Vec};
+
+    #[contract]
+    pub struct PlainPanicPlugin;
+
+    #[contractimpl]
+    impl PlainPanicPlugin {
+        pub fn on_install(_env: &Env, _source: Address) {}
+        pub fn on_uninstall(_env: &Env, _source: Address) {}
+        #[allow(clippy::panic)]
+        pub fn on_auth(_env: &Env, _source: Address, _contexts: Vec<Context>) {
+            panic!("buggy plugin — this should block auth, not be skipped");
+        }
+    }
+}
+
+#[test]
+fn test_plugin_plain_panic_is_fail_closed() {
+    let env = setup();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let smart_account_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let plugin_id = env.register(panicking_plugin::PlainPanicPlugin, ());
+    env.as_contract(&smart_account_id, || {
+        SmartAccount::install_plugin(&env, plugin_id.clone())
+    })
+    .unwrap();
+
+    let payload = BytesN::random(&env);
+    let (admin_key, admin_proof) = admin.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(soroban_sdk::map![&env, (admin_key, admin_proof)]);
+
+    let result = env.try_invoke_contract_check_auth::<Error>(
+        &smart_account_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &vec![&env, get_token_auth_context(&env)],
+    );
+
+    // plain `panic!` → Err(Ok(_)) classification → PluginOnAuthFailed.
+    assert_eq!(result, Err(Ok(Error::PluginOnAuthFailed)));
+}


### PR DESCRIPTION
## Summary

The inline comment next to the `Err(Err(_))` arm in `authorizer.rs::call_plugins_on_auth` listed *"panic!, host trap, TTL expiry"* together in the fail-open branch. That is inaccurate on Soroban 22.

**Actual classification**, pinned by the new test:

| Plugin outcome | `try_*` shape | Behaviour |
|----------------|---------------|-----------|
| normal return | `Ok(Ok(_))` | continue |
| ABI return-type mismatch | `Ok(Err(_))` | SKIP (fail-open) |
| `contracterror` / `panic_with_error!` / plain `panic!` / `unwrap()` / overflow | `Err(Ok(_))` | REJECT (fail-closed) |
| host trap — archival, budget, missing code, stack overflow | `Err(Err(_))` | SKIP (fail-open) |

The practical implication: a buggy plugin that panics at runtime will **block** authorization (fail-closed) — it will not be silently bypassed. The fail-open path is environmental only.

This is a docs-only PR plus a regression test.

## Changes

- Rewrite the comment block above the `match res {` to match reality and to note explicitly that plain `panic!` and `unwrap()` are fail-closed.
- Add `test_plugin_plain_panic_is_fail_closed` to `plugin_test.rs` — installs a plugin whose `on_auth` does `panic!(...)` and asserts `__check_auth` returns `Err(Ok(Error::PluginOnAuthFailed))`. Future Soroban runtime changes that alter this classification will surface here.

## Test plan

- [x] `test_plugin_plain_panic_is_fail_closed` — plain `panic!` blocks auth.
- [x] Existing `test_plugin_intentional_rejection_blocks_auth` — `panic_with_error!` also blocks auth (documents symmetry).
- [x] Existing `test_uninstall_plugin_persists_removal` and `test_max_plugins_limit` unaffected.

## Why not also pin the fail-open branch?

`Err(Err(_))` requires an actual host trap (archival, budget exhaustion, missing contract). Those are hard to simulate deterministically in a unit test without fixture setup proportional to the payoff, and the Soroban SDK doesn't expose a stable way to force them. The classification of the common branches is pinned; fail-open-under-trap is documented but not asserted.