### PR TITLE
fix: reject limit == i128::MAX in TokenTransferPolicy

### DIFF
--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -179,7 +179,11 @@ impl AuthorizationCheck for TokenTransferPolicy {
 
 fn validate_policy(policy: &TokenTransferPolicy, env: &Env) -> Result<(), SmartAccountError> {
     if let Some(limit) = policy.limit {
-        if limit <= 0 {
+        // `<= 0` rejects zero and negative limits. `== i128::MAX` is also
+        // rejected: `extract_transfer_total` and `check_spending_limit`
+        // saturate on overflow, so `limit == i128::MAX` would degenerate
+        // into unlimited spending (`new_total > i128::MAX` is never true).
+        if limit <= 0 || limit == i128::MAX {
             return Err(SmartAccountError::InvalidPolicy);
         }
     }

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -928,3 +928,19 @@ fn test_updating_allowed_recipients_preserves_spending_tracker() {
     let contexts = vec![&env, make_transfer_context(&env, &token, &allowed_2, 300)];
     check_auth(&env, &contract_id, &signer, &contexts).unwrap();
 }
+
+// ============================================================================
+// validate_policy must reject `limit = Some(i128::MAX)`.
+// With saturating-adds in extract_transfer_total / check_spending_limit,
+// a MAX limit silently degenerates into unlimited spending.
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "#80")]
+fn test_on_add_rejects_i128_max_limit() {
+    let env = setup();
+    let token = Address::generate(&env);
+    let mut policy = make_policy(&env, &token, Some(1000));
+    policy.limit = Some(i128::MAX);
+    let _ = setup_account_with_policy(&env, &policy);
+}


### PR DESCRIPTION
## Summary

`TokenTransferPolicy` arithmetic in `extract_transfer_total` and `check_spending_limit` uses saturating adds (`checked_add(...).unwrap_or(i128::MAX)`). That design is safe for any `limit < i128::MAX`, because the subsequent `new_total > limit` comparison correctly rejects saturated values.

It is **not** safe for `limit == i128::MAX`:

- `new_total = tracker.spent.checked_add(total_amount).unwrap_or(i128::MAX)`
- `if new_total > limit` → `if i128::MAX > i128::MAX` → `false`
- Every spend passes, the tracker saturates at `i128::MAX`, and it stays there.

So `limit = Some(i128::MAX)` silently degenerates into unlimited spending.

`validate_policy` already rejects `limit <= 0`. Extend the guard to also reject `limit == i128::MAX`, using the same `InvalidPolicy` error code (the surface to integrators is unchanged: pass a sensible positive bound).

## Test plan

- [x] New `test_on_add_rejects_i128_max_limit` — registering a signer with `limit = Some(i128::MAX)` panics with `InvalidPolicy (#80)`.
- [x] Existing `test_on_add_rejects_zero_limit` / `test_on_add_rejects_negative_limit` still pass — same code path, same error.
- [x] Full suite: 40 `token_transfer_policy_test` cases pass (39 existing + 1 new).

## Risk

Trivial. Anyone who had configured `i128::MAX` on purpose was misconfigured (unlimited spending dressed up as a tracked cap). If that's the intent, the correct configuration is `limit: None`, which bypasses the tracker entirely.