### PR TITLE
fix: surface SignerAlreadyExists from add_signer

### DIFF
--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -162,7 +162,18 @@ impl SmartAccountInterface for SmartAccount {
 
         let key = signer.clone().into();
         let storage = Storage::persistent();
-        storage.store::<SignerKey, Signer>(env, &key, &signer)?;
+        storage
+            .store::<SignerKey, Signer>(env, &key, &signer)
+            .map_err(|e| {
+                // The domain-specific SignerAlreadyExists conveys intent more
+                // clearly than the generic storage error.
+                let surfaced = SmartAccountError::from(e);
+                if surfaced == SmartAccountError::StorageEntryAlreadyExists {
+                    SmartAccountError::SignerAlreadyExists
+                } else {
+                    surfaced
+                }
+            })?;
         storage.extend_ttl(env, &key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_EXTEND_TO);
 
         // Handle role-specific initialization

--- a/contracts/smart-account/src/tests/auth_test.rs
+++ b/contracts/smart-account/src/tests/auth_test.rs
@@ -438,7 +438,9 @@ fn test_auth_idempotency() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #11)")]
+// SignerAlreadyExists (21) — previously surfaced as the generic
+// StorageEntryAlreadyExists (11); see add_signer in account.rs.
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_constructor_duplicate_signers() {
     let env = setup();
     let test_signer = Ed25519TestSigner::generate(SignerRole::Admin);

--- a/contracts/smart-account/src/tests/signer_management_test.rs
+++ b/contracts/smart-account/src/tests/signer_management_test.rs
@@ -280,3 +280,37 @@ fn test_get_signer_returns_error_when_signer_does_not_exist() {
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), Error::SignerNotFound);
 }
+
+// ============================================================================
+// add_signer surfaces SignerAlreadyExists (not StorageEntryAlreadyExists)
+// when the same key is added twice — the domain-specific error code makes
+// the caller's mistake obvious.
+// ============================================================================
+
+#[test]
+fn test_add_duplicate_signer_returns_signer_already_exists() {
+    let env = setup();
+    let admin_signer = Ed25519TestSigner::generate(SignerRole::Admin);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin_signer.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+    env.mock_all_auths();
+
+    // Standard signer we will add once then try to re-add.
+    let dup = Ed25519TestSigner::generate(SignerRole::Standard(None, 0));
+    env.as_contract(&contract_id, || {
+        SmartAccount::add_signer(&env, dup.into_signer(&env))
+    })
+    .unwrap();
+
+    let err = env
+        .as_contract(&contract_id, || {
+            SmartAccount::add_signer(&env, dup.into_signer(&env))
+        })
+        .unwrap_err();
+    assert_eq!(err, Error::SignerAlreadyExists);
+}


### PR DESCRIPTION
## Summary

`add_signer` relied on `Storage::store`'s `AlreadyExists` mapping (`SmartAccountError::StorageEntryAlreadyExists = 11`) when a caller attempted to add a signer key that was already registered. The domain error the interfaces crate declared for this case — `SmartAccountError::SignerAlreadyExists = 21` — was defined but never emitted.

Integrators matching on the declared domain error saw code 11 at runtime and had to learn the undocumented translation.

This PR translates the specific `StorageEntryAlreadyExists` → `SignerAlreadyExists` in `add_signer`. All other storage errors pass through unchanged.

## Changes

- `account.rs::add_signer`: wrap the `storage.store` call in `.map_err` that promotes the specific "already exists" case to `SignerAlreadyExists` while preserving every other error verbatim.
- `tests/signer_management_test.rs`: new `test_add_duplicate_signer_returns_signer_already_exists` — asserts `add_signer(dup) → Err(SignerAlreadyExists)`.
- `tests/auth_test.rs::test_constructor_duplicate_signers`: update `#[should_panic]` expectation from `#11` to `#21` (the only existing test that was keying off the old code). The comment documents the change.

## Test plan

- [x] New direct test passes: duplicate `add_signer` returns `SignerAlreadyExists`.
- [x] Updated `test_constructor_duplicate_signers` passes with `#21`.
- [x] Full suite: 127 passed, 0 failed.

## Semantic impact for external callers

This is a user-observable error-code change: anyone catching `#11` on duplicate signer operations must update to `#21`. Given the previous code was an interfaces-crate domain error that went unused, the change aligns the runtime with the declared contract surface. The generic `StorageEntryAlreadyExists` remains valid for any other storage path that ever returns it.