### PR TITLE
feat(withdraw-proxy): atomic Rain collateral pull + transfer router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "withdraw-proxy"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "contracts/contract-factory",
   "contracts/examples/plugin-policy-example",
+  "contracts/examples/withdraw-proxy",
   "contracts/initializable",
   "contracts/smart-account",
   "contracts/smart-account-interfaces",

--- a/contracts/examples/withdraw-proxy/Cargo.toml
+++ b/contracts/examples/withdraw-proxy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "withdraw-proxy"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/examples/withdraw-proxy/src/lib.rs
+++ b/contracts/examples/withdraw-proxy/src/lib.rs
@@ -3,80 +3,41 @@
 
 //! # Withdraw Proxy
 //!
-//! Atomic "pull-from-collateral-and-send" router for Rain card collateral on Stellar.
+//! Atomic withdraw-then-transfer router. In one invocation it pulls `withdraw_amount` out of a
+//! Coordinator-managed account back into `caller`, asserts the balance rose by exactly that
+//! amount, then transfers `transfer_amount` from `caller` to `recipient` — both moves succeed or
+//! the whole transaction reverts.
 //!
-//! A Crossmint smart wallet can hold a token both directly and as collateral backing a Rain
-//! card. This contract lets a SINGLE atomic transaction fund a transfer from BOTH sources: it
-//! pulls a portion out of the Rain collateral (via the Rain Coordinator) back INTO the wallet,
-//! verifies the wallet received exactly that amount, then sends the recipient's payment from the
-//! wallet.
-//!
-//! ## Flow
-//!
-//! 1. `coordinator.withdraw_assets(caller = wallet, …, recipient = wallet, withdraw_amount)` —
-//!    the collateral is returned to the **wallet itself** (Rain's signature only ever authorizes
-//!    returning collateral to its owner, never to a third party).
-//! 2. Assert `balance(wallet)` increased by **exactly** `withdraw_amount` — so a buggy or
-//!    malicious Coordinator that moved nothing, or the wrong amount, reverts the whole tx.
-//! 3. `token.transfer(from = wallet, to = recipient, transfer_amount)` — the recipient gets one
-//!    clean transfer from the wallet.
-//!
-//! ## Why a proxy is needed
-//!
-//! The Crossmint Stellar smart account is auth-only (it implements `__check_auth` but has no
-//! `execute`/batch entrypoint), and a Stellar transaction carries a single `InvokeHostFunction`
-//! operation. So the wallet cannot itself be the root that dispatches two contract calls. This
-//! proxy is that root: both sub-calls pass the SAME `caller` (the wallet), so the host presents
-//! both to the wallet's `__check_auth` together — ONE wallet signature authorizes the whole
-//! bundle, and it is atomic (the recipient is paid in full or nothing moves).
-//!
-//! ## Token & units
-//!
-//! The token is a parameter, not hard-coded — but the contract asserts it reports
-//! [`EXPECTED_DECIMALS`] (7), the Stellar USDC precision, so the raw amounts here line up with
-//! the cents→smallest-units conversion the caller does off-chain (Rain's API speaks cents).
-//! Every `*_amount` is a token SMALLEST UNIT; the contract performs no conversion.
-//!
-//! ## Trust
-//!
-//! The proxy holds no funds and no approvals, and can never move a wallet's funds on its own:
-//! both legs require the wallet's own authorization (`require_auth(caller)`), the collateral leg
-//! additionally requires Rain's detached co-signature (in [`WithdrawAuth`], verified inside the
-//! Coordinator), and the balance assertion means the proxy never trusts the Coordinator's word
-//! for the withdrawn amount.
+//! Both sub-calls pass the same `caller`, so the host gathers them under a single authorization
+//! tree: one signature covers the root invocation and both legs. The proxy holds no funds and no
+//! approvals, so it can never move funds the caller did not authorize.
 
 use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
     Env, Symbol,
 };
 
-/// Token precision the proxy is built for (Stellar USDC = 7 decimals). Asserted on-chain so the
-/// raw amounts match the caller's off-chain cents→smallest-units conversion.
+/// Token precision the proxy supports, asserted on-chain. All amounts are token smallest units.
 pub const EXPECTED_DECIMALS: u32 = 7;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    /// `transfer_amount` or `withdraw_amount` was not strictly positive. This proxy exists for
-    /// the split case (both wallet and collateral contribute); a zero leg means the caller
-    /// should use a plain transfer or a single `withdraw_assets` call instead.
+    /// `transfer_amount` or `withdraw_amount` was not strictly positive.
     NonPositiveAmount = 1,
     /// The token does not report [`EXPECTED_DECIMALS`] decimals.
     UnsupportedToken = 2,
-    /// The wallet's balance did not increase by exactly `withdraw_amount` after the withdrawal —
-    /// the Coordinator did not deliver what was requested. The whole transaction reverts.
+    /// `caller`'s balance did not increase by exactly `withdraw_amount` after the withdrawal.
     WithdrawAmountMismatch = 3,
 }
 
-/// Rain's withdrawal authorization, as returned by the Rain withdrawal-signature API and
-/// verified inside the Coordinator. These fields are opaque to this proxy — it only forwards
-/// them to [`Coordinator::withdraw_assets`].
+/// Withdrawal authorization forwarded verbatim to [`Coordinator::withdraw_assets`]; opaque to
+/// this proxy.
 ///
-/// NOTE: the byte widths below mirror an ed25519 scheme (32-byte key, 32-byte salt, 64-byte
-/// signature). The published SignifyHQ example passes these as dynamic `Bytes`; confirm the
-/// exact widths and dynamic-vs-fixed encoding against the deployed Rain Coordinator before
-/// mainnet use, and adjust both this struct and the [`Coordinator`] client to match.
+/// NOTE: the byte widths mirror an ed25519 scheme (32-byte key, 32-byte salt, 64-byte signature).
+/// Confirm the exact widths and fixed-vs-dynamic encoding against the deployed Coordinator before
+/// mainnet use, and adjust this struct and the [`Coordinator`] client to match.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WithdrawAuth {
@@ -86,10 +47,7 @@ pub struct WithdrawAuth {
     pub signature: BytesN<64>,
 }
 
-/// Minimal view of the Rain Coordinator contract's withdrawal entrypoint, used only to issue a
-/// typed cross-contract call. The Coordinator verifies Rain's detached signature in-contract and
-/// enforces `caller == the collateral's registered owner`, then releases `amount` of `asset`
-/// from `collateral` to `recipient`.
+/// Typed view of the Coordinator's withdrawal entrypoint, used to issue the cross-contract call.
 #[contractclient(name = "CoordinatorClient")]
 pub trait Coordinator {
     fn withdraw_assets(
@@ -111,16 +69,12 @@ pub struct WithdrawProxy;
 
 #[contractimpl]
 impl WithdrawProxy {
-    /// Atomically pull `withdraw_amount` of `token` out of the Rain `collateral` (via
-    /// `coordinator`) back into the wallet, verify it arrived exactly, then send
-    /// `transfer_amount` from the wallet to `recipient`.
+    /// Pull `withdraw_amount` of `token` from `collateral` (via `coordinator`) into `caller`,
+    /// verify it arrived exactly, then transfer `transfer_amount` from `caller` to `recipient`.
+    /// `token` must report [`EXPECTED_DECIMALS`] decimals; all amounts are token smallest units.
     ///
-    /// `caller` is the collateral owner (the user's wallet) and the withdrawal recipient.
-    /// `token` is both the withdrawn asset and the transferred token; it must report
-    /// [`EXPECTED_DECIMALS`] decimals. All amounts are token SMALLEST UNITS.
-    ///
-    /// Reverts (nothing moves) if a guard fails, if the wallet's balance does not increase by
-    /// exactly `withdraw_amount`, if the Coordinator rejects, or if the wallet cannot cover
+    /// Reverts without moving funds if a guard fails, if `caller`'s balance does not increase by
+    /// exactly `withdraw_amount`, if the Coordinator rejects, or if `caller` cannot cover
     /// `transfer_amount`.
     pub fn withdraw_and_transfer(
         env: Env,
@@ -133,9 +87,8 @@ impl WithdrawProxy {
         transfer_amount: i128,
         auth: WithdrawAuth,
     ) -> Result<(), Error> {
-        // Authenticate the wallet up front. Both sub-calls below additionally re-check
-        // `require_auth(caller)`, so a single wallet signature covers this invocation and both
-        // legs; an attacker cannot drive funds out of a wallet that did not authorize.
+        // One signature covers this invocation and both legs: they share `caller`, so the host
+        // presents them under a single authorization tree.
         caller.require_auth();
 
         if transfer_amount <= 0 || withdraw_amount <= 0 {
@@ -147,8 +100,6 @@ impl WithdrawProxy {
             return Err(Error::UnsupportedToken);
         }
 
-        // Leg 1 — pull the shortfall out of Rain collateral back into the wallet (recipient =
-        // caller). The Coordinator verifies Rain's detached co-signature (`auth`).
         let balance_before = token_client.balance(&caller);
         CoordinatorClient::new(&env, &coordinator).withdraw_assets(
             &caller,
@@ -161,13 +112,11 @@ impl WithdrawProxy {
             &auth.signature,
             &auth.public_key,
         );
-        // Verify the Coordinator delivered exactly what was requested. If not, revert everything
-        // — we never trust the Coordinator's word for the amount.
+        // Check the on-ledger balance rather than trusting the Coordinator's reported amount.
         if token_client.balance(&caller) != balance_before + withdraw_amount {
             return Err(Error::WithdrawAmountMismatch);
         }
 
-        // Leg 2 — send the recipient's payment from the wallet.
         token_client.transfer(&caller, &recipient, &transfer_amount);
 
         env.events().publish(

--- a/contracts/examples/withdraw-proxy/src/lib.rs
+++ b/contracts/examples/withdraw-proxy/src/lib.rs
@@ -1,0 +1,183 @@
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+//! # Withdraw Proxy
+//!
+//! Atomic "pull-from-collateral-and-send" router for Rain card collateral on Stellar.
+//!
+//! A Crossmint smart wallet can hold a token both directly and as collateral backing a Rain
+//! card. This contract lets a SINGLE atomic transaction fund a transfer from BOTH sources: it
+//! pulls a portion out of the Rain collateral (via the Rain Coordinator) back INTO the wallet,
+//! verifies the wallet received exactly that amount, then sends the recipient's payment from the
+//! wallet.
+//!
+//! ## Flow
+//!
+//! 1. `coordinator.withdraw_assets(caller = wallet, …, recipient = wallet, withdraw_amount)` —
+//!    the collateral is returned to the **wallet itself** (Rain's signature only ever authorizes
+//!    returning collateral to its owner, never to a third party).
+//! 2. Assert `balance(wallet)` increased by **exactly** `withdraw_amount` — so a buggy or
+//!    malicious Coordinator that moved nothing, or the wrong amount, reverts the whole tx.
+//! 3. `token.transfer(from = wallet, to = recipient, transfer_amount)` — the recipient gets one
+//!    clean transfer from the wallet.
+//!
+//! ## Why a proxy is needed
+//!
+//! The Crossmint Stellar smart account is auth-only (it implements `__check_auth` but has no
+//! `execute`/batch entrypoint), and a Stellar transaction carries a single `InvokeHostFunction`
+//! operation. So the wallet cannot itself be the root that dispatches two contract calls. This
+//! proxy is that root: both sub-calls pass the SAME `caller` (the wallet), so the host presents
+//! both to the wallet's `__check_auth` together — ONE wallet signature authorizes the whole
+//! bundle, and it is atomic (the recipient is paid in full or nothing moves).
+//!
+//! ## Token & units
+//!
+//! The token is a parameter, not hard-coded — but the contract asserts it reports
+//! [`EXPECTED_DECIMALS`] (7), the Stellar USDC precision, so the raw amounts here line up with
+//! the cents→smallest-units conversion the caller does off-chain (Rain's API speaks cents).
+//! Every `*_amount` is a token SMALLEST UNIT; the contract performs no conversion.
+//!
+//! ## Trust
+//!
+//! The proxy holds no funds and no approvals, and can never move a wallet's funds on its own:
+//! both legs require the wallet's own authorization (`require_auth(caller)`), the collateral leg
+//! additionally requires Rain's detached co-signature (in [`WithdrawAuth`], verified inside the
+//! Coordinator), and the balance assertion means the proxy never trusts the Coordinator's word
+//! for the withdrawn amount.
+
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
+    Env, Symbol,
+};
+
+/// Token precision the proxy is built for (Stellar USDC = 7 decimals). Asserted on-chain so the
+/// raw amounts match the caller's off-chain cents→smallest-units conversion.
+pub const EXPECTED_DECIMALS: u32 = 7;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// `transfer_amount` or `withdraw_amount` was not strictly positive. This proxy exists for
+    /// the split case (both wallet and collateral contribute); a zero leg means the caller
+    /// should use a plain transfer or a single `withdraw_assets` call instead.
+    NonPositiveAmount = 1,
+    /// The token does not report [`EXPECTED_DECIMALS`] decimals.
+    UnsupportedToken = 2,
+    /// The wallet's balance did not increase by exactly `withdraw_amount` after the withdrawal —
+    /// the Coordinator did not deliver what was requested. The whole transaction reverts.
+    WithdrawAmountMismatch = 3,
+}
+
+/// Rain's withdrawal authorization, as returned by the Rain withdrawal-signature API and
+/// verified inside the Coordinator. These fields are opaque to this proxy — it only forwards
+/// them to [`Coordinator::withdraw_assets`].
+///
+/// NOTE: the byte widths below mirror an ed25519 scheme (32-byte key, 32-byte salt, 64-byte
+/// signature). The published SignifyHQ example passes these as dynamic `Bytes`; confirm the
+/// exact widths and dynamic-vs-fixed encoding against the deployed Rain Coordinator before
+/// mainnet use, and adjust both this struct and the [`Coordinator`] client to match.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawAuth {
+    pub expires_at: u64,
+    pub public_key: BytesN<32>,
+    pub salt: BytesN<32>,
+    pub signature: BytesN<64>,
+}
+
+/// Minimal view of the Rain Coordinator contract's withdrawal entrypoint, used only to issue a
+/// typed cross-contract call. The Coordinator verifies Rain's detached signature in-contract and
+/// enforces `caller == the collateral's registered owner`, then releases `amount` of `asset`
+/// from `collateral` to `recipient`.
+#[contractclient(name = "CoordinatorClient")]
+pub trait Coordinator {
+    fn withdraw_assets(
+        env: Env,
+        caller: Address,
+        collateral: Address,
+        asset: Address,
+        amount: i128,
+        recipient: Address,
+        expires_at: u64,
+        salt: BytesN<32>,
+        signature: BytesN<64>,
+        public_key: BytesN<32>,
+    );
+}
+
+#[contract]
+pub struct WithdrawProxy;
+
+#[contractimpl]
+impl WithdrawProxy {
+    /// Atomically pull `withdraw_amount` of `token` out of the Rain `collateral` (via
+    /// `coordinator`) back into the wallet, verify it arrived exactly, then send
+    /// `transfer_amount` from the wallet to `recipient`.
+    ///
+    /// `caller` is the collateral owner (the user's wallet) and the withdrawal recipient.
+    /// `token` is both the withdrawn asset and the transferred token; it must report
+    /// [`EXPECTED_DECIMALS`] decimals. All amounts are token SMALLEST UNITS.
+    ///
+    /// Reverts (nothing moves) if a guard fails, if the wallet's balance does not increase by
+    /// exactly `withdraw_amount`, if the Coordinator rejects, or if the wallet cannot cover
+    /// `transfer_amount`.
+    pub fn withdraw_and_transfer(
+        env: Env,
+        caller: Address,
+        coordinator: Address,
+        collateral: Address,
+        token: Address,
+        recipient: Address,
+        withdraw_amount: i128,
+        transfer_amount: i128,
+        auth: WithdrawAuth,
+    ) -> Result<(), Error> {
+        // Authenticate the wallet up front. Both sub-calls below additionally re-check
+        // `require_auth(caller)`, so a single wallet signature covers this invocation and both
+        // legs; an attacker cannot drive funds out of a wallet that did not authorize.
+        caller.require_auth();
+
+        if transfer_amount <= 0 || withdraw_amount <= 0 {
+            return Err(Error::NonPositiveAmount);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        if token_client.decimals() != EXPECTED_DECIMALS {
+            return Err(Error::UnsupportedToken);
+        }
+
+        // Leg 1 — pull the shortfall out of Rain collateral back into the wallet (recipient =
+        // caller). The Coordinator verifies Rain's detached co-signature (`auth`).
+        let balance_before = token_client.balance(&caller);
+        CoordinatorClient::new(&env, &coordinator).withdraw_assets(
+            &caller,
+            &collateral,
+            &token,
+            &withdraw_amount,
+            &caller,
+            &auth.expires_at,
+            &auth.salt,
+            &auth.signature,
+            &auth.public_key,
+        );
+        // Verify the Coordinator delivered exactly what was requested. If not, revert everything
+        // — we never trust the Coordinator's word for the amount.
+        if token_client.balance(&caller) != balance_before + withdraw_amount {
+            return Err(Error::WithdrawAmountMismatch);
+        }
+
+        // Leg 2 — send the recipient's payment from the wallet.
+        token_client.transfer(&caller, &recipient, &transfer_amount);
+
+        env.events().publish(
+            (Symbol::new(&env, "withdraw_and_transfer"), caller),
+            (recipient, withdraw_amount, transfer_amount),
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/examples/withdraw-proxy/src/test.rs
+++ b/contracts/examples/withdraw-proxy/src/test.rs
@@ -1,0 +1,306 @@
+extern crate std;
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, BytesN, Env};
+
+use crate::{Error, WithdrawAuth, WithdrawProxy, WithdrawProxyClient};
+
+// Stand-ins for Rain's Coordinator. A real Coordinator verifies Rain's detached signature and
+// checks `caller == the collateral's registered owner`; here we just move funds from `collateral`
+// to `recipient` (the wallet) so the proxy's effect is observable on-ledger.
+//
+// Each mock lives in its own module because `#[contractimpl]` emits module-level items keyed by
+// the function name, which would otherwise collide between mocks.
+mod mock_coordinator {
+    use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
+
+    #[contract]
+    pub struct MockCoordinator;
+
+    #[contractimpl]
+    impl MockCoordinator {
+        pub fn withdraw_assets(
+            env: Env,
+            caller: Address,
+            collateral: Address,
+            asset: Address,
+            amount: i128,
+            recipient: Address,
+            _expires_at: u64,
+            _salt: BytesN<32>,
+            _signature: BytesN<64>,
+            _public_key: BytesN<32>,
+        ) {
+            let _ = caller;
+            token::Client::new(&env, &asset).transfer(&collateral, &recipient, &amount);
+        }
+    }
+}
+
+// A Coordinator that always rejects, to prove the whole transaction reverts atomically.
+mod failing_coordinator {
+    use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+
+    #[contract]
+    pub struct FailingCoordinator;
+
+    #[contractimpl]
+    impl FailingCoordinator {
+        pub fn withdraw_assets(
+            _env: Env,
+            _caller: Address,
+            _collateral: Address,
+            _asset: Address,
+            _amount: i128,
+            _recipient: Address,
+            _expires_at: u64,
+            _salt: BytesN<32>,
+            _signature: BytesN<64>,
+            _public_key: BytesN<32>,
+        ) {
+            panic!("coordinator rejected the withdrawal");
+        }
+    }
+}
+
+// A Coordinator that "succeeds" but delivers the wrong amount (one more than requested), to prove
+// the balance assertion catches it and reverts the (over-)withdrawal.
+mod lying_coordinator {
+    use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
+
+    #[contract]
+    pub struct LyingCoordinator;
+
+    #[contractimpl]
+    impl LyingCoordinator {
+        pub fn withdraw_assets(
+            env: Env,
+            _caller: Address,
+            collateral: Address,
+            asset: Address,
+            amount: i128,
+            recipient: Address,
+            _expires_at: u64,
+            _salt: BytesN<32>,
+            _signature: BytesN<64>,
+            _public_key: BytesN<32>,
+        ) {
+            token::Client::new(&env, &asset).transfer(&collateral, &recipient, &(amount + 1));
+        }
+    }
+}
+
+// A token reporting 4 decimals, to prove the proxy rejects non-7-decimal tokens.
+mod four_dp_token {
+    use soroban_sdk::{contract, contractimpl, Env};
+
+    #[contract]
+    pub struct FourDpToken;
+
+    #[contractimpl]
+    impl FourDpToken {
+        pub fn decimals(_env: Env) -> u32 {
+            4
+        }
+    }
+}
+
+use failing_coordinator::FailingCoordinator;
+use four_dp_token::FourDpToken;
+use lying_coordinator::LyingCoordinator;
+use mock_coordinator::MockCoordinator;
+
+fn dummy_auth(env: &Env) -> WithdrawAuth {
+    WithdrawAuth {
+        expires_at: 0,
+        public_key: BytesN::from_array(env, &[7u8; 32]),
+        salt: BytesN::from_array(env, &[9u8; 32]),
+        signature: BytesN::from_array(env, &[3u8; 64]),
+    }
+}
+
+struct Harness {
+    env: Env,
+    proxy_id: Address,
+    usdc: Address,
+    wallet: Address,
+    collateral: Address,
+    recipient: Address,
+}
+
+fn setup(wallet_balance: i128, collateral_balance: i128) -> Harness {
+    let env = Env::default();
+    // The mock Coordinators move funds via `token.transfer(from = collateral)`, which requires
+    // `collateral`'s auth deep in the call tree (the real Coordinator instead releases collateral
+    // on Rain's signature, with no such require_auth). Allow that non-root auth.
+    env.mock_all_auths_allowing_non_root_auth();
+
+    // A Stellar Asset Contract reports 7 decimals — matching the proxy's EXPECTED_DECIMALS.
+    let sac_admin = Address::generate(&env);
+    let usdc = env.register_stellar_asset_contract_v2(sac_admin).address();
+    let mint = token::StellarAssetClient::new(&env, &usdc);
+
+    let wallet = Address::generate(&env);
+    let collateral = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint.mint(&wallet, &wallet_balance);
+    mint.mint(&collateral, &collateral_balance);
+
+    let proxy_id = env.register(WithdrawProxy, ());
+
+    Harness {
+        env,
+        proxy_id,
+        usdc,
+        wallet,
+        collateral,
+        recipient,
+    }
+}
+
+#[test]
+fn funds_recipient_from_both_sources() {
+    // Wallet 300 + pull 700 from collateral → wallet holds 1000, then sends 1000 to recipient.
+    let h = setup(300, 5_000);
+    let coordinator = h.env.register(MockCoordinator, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    proxy.withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &h.usdc,
+        &h.recipient,
+        &700i128,   // withdrawn into the wallet
+        &1_000i128, // sent to the recipient
+        &dummy_auth(&h.env),
+    );
+
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.recipient), 1_000); // one clean transfer
+    assert_eq!(token.balance(&h.wallet), 0); // 300 + 700 - 1000
+    assert_eq!(token.balance(&h.collateral), 4_300); // 5000 - 700
+}
+
+#[test]
+fn reverts_atomically_when_transfer_leg_fails() {
+    // Wallet 100 + pull 700 = 800, but asked to send 900. The withdraw landed first; the failing
+    // transfer must roll the whole transaction back.
+    let h = setup(100, 5_000);
+    let coordinator = h.env.register(MockCoordinator, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    let res = proxy.try_withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &h.usdc,
+        &h.recipient,
+        &700i128,
+        &900i128,
+        &dummy_auth(&h.env),
+    );
+
+    assert!(res.is_err());
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.recipient), 0); // nothing delivered
+    assert_eq!(token.balance(&h.collateral), 5_000); // withdraw rolled back
+    assert_eq!(token.balance(&h.wallet), 100); // untouched
+}
+
+#[test]
+fn reverts_atomically_when_coordinator_rejects() {
+    let h = setup(300, 5_000);
+    let coordinator = h.env.register(FailingCoordinator, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    let res = proxy.try_withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &h.usdc,
+        &h.recipient,
+        &700i128,
+        &1_000i128,
+        &dummy_auth(&h.env),
+    );
+
+    assert!(res.is_err());
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.recipient), 0);
+    assert_eq!(token.balance(&h.wallet), 300);
+    assert_eq!(token.balance(&h.collateral), 5_000);
+}
+
+#[test]
+fn reverts_when_withdraw_delivers_wrong_amount() {
+    // The Coordinator "succeeds" but moves 701 instead of 700. The balance assertion must fail
+    // and revert the over-withdrawal — proving the proxy never trusts the Coordinator's word.
+    let h = setup(300, 5_000);
+    let coordinator = h.env.register(LyingCoordinator, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    let res = proxy.try_withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &h.usdc,
+        &h.recipient,
+        &700i128,
+        &1_000i128,
+        &dummy_auth(&h.env),
+    );
+
+    assert!(matches!(res, Err(Ok(Error::WithdrawAmountMismatch))));
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.collateral), 5_000); // over-withdrawal rolled back
+    assert_eq!(token.balance(&h.wallet), 300);
+    assert_eq!(token.balance(&h.recipient), 0);
+}
+
+#[test]
+fn rejects_non_positive_amounts() {
+    let h = setup(300, 5_000);
+    let coordinator = h.env.register(MockCoordinator, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    let res = proxy.try_withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &h.usdc,
+        &h.recipient,
+        &700i128,
+        &0i128, // invalid
+        &dummy_auth(&h.env),
+    );
+
+    assert!(matches!(res, Err(Ok(Error::NonPositiveAmount))));
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.recipient), 0);
+    assert_eq!(token.balance(&h.collateral), 5_000);
+}
+
+#[test]
+fn rejects_token_with_unexpected_decimals() {
+    let h = setup(300, 5_000);
+    let coordinator = h.env.register(MockCoordinator, ());
+    let bad_token = h.env.register(FourDpToken, ());
+    let proxy = WithdrawProxyClient::new(&h.env, &h.proxy_id);
+
+    let res = proxy.try_withdraw_and_transfer(
+        &h.wallet,
+        &coordinator,
+        &h.collateral,
+        &bad_token, // reports 4 decimals
+        &h.recipient,
+        &700i128,
+        &1_000i128,
+        &dummy_auth(&h.env),
+    );
+
+    assert!(matches!(res, Err(Ok(Error::UnsupportedToken))));
+    let token = token::Client::new(&h.env, &h.usdc);
+    assert_eq!(token.balance(&h.collateral), 5_000);
+    assert_eq!(token.balance(&h.wallet), 300);
+}

--- a/contracts/examples/withdraw-proxy/src/test.rs
+++ b/contracts/examples/withdraw-proxy/src/test.rs
@@ -5,9 +5,8 @@ use soroban_sdk::{token, Address, BytesN, Env};
 
 use crate::{Error, WithdrawAuth, WithdrawProxy, WithdrawProxyClient};
 
-// Stand-ins for Rain's Coordinator. A real Coordinator verifies Rain's detached signature and
-// checks `caller == the collateral's registered owner`; here we just move funds from `collateral`
-// to `recipient` (the wallet) so the proxy's effect is observable on-ledger.
+// Coordinator stand-in: moves `amount` from `collateral` to `recipient` so the proxy's effect is
+// observable on-ledger.
 //
 // Each mock lives in its own module because `#[contractimpl]` emits module-level items keyed by
 // the function name, which would otherwise collide between mocks.
@@ -63,8 +62,8 @@ mod failing_coordinator {
     }
 }
 
-// A Coordinator that "succeeds" but delivers the wrong amount (one more than requested), to prove
-// the balance assertion catches it and reverts the (over-)withdrawal.
+// A Coordinator that "succeeds" but delivers one more than requested, to prove the balance check
+// catches it and reverts.
 mod lying_coordinator {
     use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env};
 
@@ -131,8 +130,7 @@ struct Harness {
 fn setup(wallet_balance: i128, collateral_balance: i128) -> Harness {
     let env = Env::default();
     // The mock Coordinators move funds via `token.transfer(from = collateral)`, which requires
-    // `collateral`'s auth deep in the call tree (the real Coordinator instead releases collateral
-    // on Rain's signature, with no such require_auth). Allow that non-root auth.
+    // `collateral`'s auth deep in the call tree. Allow that non-root auth.
     env.mock_all_auths_allowing_non_root_auth();
 
     // A Stellar Asset Contract reports 7 decimals — matching the proxy's EXPECTED_DECIMALS.


### PR DESCRIPTION
## What

A PoC Soroban **router** contract for collateral-funded sends. In one atomic transaction it pulls a portion out of a Rain card's collateral **back into the wallet**, verifies the wallet received exactly that amount, then sends the recipient's payment from the wallet — so a send can be funded jointly by the wallet and its collateral, or fully revert.

The Crossmint Stellar smart account is auth-only and a Stellar transaction carries a single `InvokeHostFunction` op, so the wallet can't itself bundle the two calls. This proxy is the root that does.

```rust
fn withdraw_and_transfer(
    caller: Address,        // collateral owner = the user's wallet (also the withdrawal recipient)
    coordinator: Address,   // Rain Coordinator
    collateral: Address,    // Rain collateral proxy
    token: Address,         // both the withdrawn asset and the transferred token
    recipient: Address,     // final recipient of transfer_amount
    withdraw_amount: i128,  // pulled from collateral into the wallet
    transfer_amount: i128,  // sent from the wallet to the recipient
    auth: WithdrawAuth,     // Rain's detached signature: { expires_at, public_key, salt, signature }
) -> Result<(), Error>
```

## Notes

- **Verifies, doesn't trust.** After the withdrawal the contract asserts the wallet's balance increased by **exactly** `withdraw_amount`; a Coordinator that delivers nothing or the wrong amount reverts the whole transaction.
- **One signature.** `caller.require_auth()` at the top roots the wallet's authorization at the router call, so both sub-call `require_auth(wallet)` contexts are covered by a single auth entry — one signature for the user, and no non-root auth entries (which the SDK doesn't enable by default).
- **Adds no new trust.** The router holds no funds; both legs self-authorize (the wallet via `require_auth`, Rain via its detached co-signature on the withdraw).
- **Token is a parameter** but the contract asserts it reports 7 decimals (Stellar USDC); amounts are token smallest units.
- Router for the "Extended Transfers for Wallets with Cards" EDD (WAL-10215). The Rain Coordinator ABI is assumed from the SignifyHQ examples and must be pinned against the deployed contract; the deployed router should also be source-verified on-chain — hence draft.

## Test plan

`cargo test -p withdraw-proxy` — 6 tests:
- funds the recipient from both sources (happy path),
- atomic revert when the transfer leg fails,
- atomic revert when the coordinator rejects,
- revert when the withdrawal delivers the wrong amount (balance assertion),
- rejects non-positive amounts,
- rejects a token that does not report 7 decimals.

Also clean: `cargo build -p withdraw-proxy --target wasm32-unknown-unknown --release`, `cargo fmt`, `cargo clippy`.
