### PR TITLE
fix(smart-account): reject upgrade while a migration is pending

### DIFF
--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -64,6 +64,7 @@ impl SmartAccountUpgradeableMigratableInternal for SmartAccount {
 impl SmartAccountUpgradeableMigratable for SmartAccount {
     fn upgrade(e: &Env, new_wasm_hash: BytesN<32>) {
         Self::_require_auth_upgrade(e);
+        upgradeable::ensure_no_pending_migration(e);
         upgradeable::enable_migration(e);
         e.events().publish(
             (Symbol::new(e, "UPGRADE_STARTED"),),

--- a/contracts/smart-account/src/tests/upgrade_test.rs
+++ b/contracts/smart-account/src/tests/upgrade_test.rs
@@ -13,9 +13,12 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, IntoVal, Symbol, Vec,
 };
 
+use crate::account::SmartAccount;
 use crate::auth::proof::{SignatureProofs, SignerProof};
 use crate::error::Error;
-use crate::tests::test_utils::get_token_auth_context;
+use crate::tests::test_utils::{get_token_auth_context, Ed25519TestSigner, TestSignerTrait as _};
+use smart_account_interfaces::SignerRole;
+use upgradeable::SmartAccountUpgradeableMigratable;
 
 // A minimal external-policy contract so the v1 constructor's `on_add` call succeeds.
 #[contract]
@@ -344,6 +347,69 @@ fn test_migrate_cannot_run_twice() {
         expected_signer_count: 0,
         expected_admin_count: 0,
     }));
+}
+
+// ============================================================================
+// Test: Upgrade cannot be called again while a migration is pending
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1110)")]
+fn test_second_upgrade_rejected_while_migration_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Register the contract natively so both upgrade calls execute the current
+    // source, not the pre-built v2 WASM snapshot in testdata.
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let v2_hash = upload_v2_wasm(&env);
+
+    // First upgrade succeeds and leaves MIGRATING = true
+    env.as_contract(&contract_id, || {
+        <SmartAccount as SmartAccountUpgradeableMigratable>::upgrade(&env, v2_hash.clone());
+    });
+
+    // Second upgrade before migrate() — must fail with MigrationAlreadyPending (1110)
+    env.as_contract(&contract_id, || {
+        <SmartAccount as SmartAccountUpgradeableMigratable>::upgrade(&env, v2_hash.clone());
+    });
+}
+
+#[test]
+fn test_upgrade_allowed_again_after_migration_completes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Ed25519TestSigner::generate(SignerRole::Admin);
+    let contract_id = env.register(
+        SmartAccount,
+        (
+            vec![&env, admin.into_signer(&env)],
+            Vec::<Address>::new(&env),
+        ),
+    );
+
+    let v2_hash = upload_v2_wasm(&env);
+
+    env.as_contract(&contract_id, || {
+        <SmartAccount as SmartAccountUpgradeableMigratable>::upgrade(&env, v2_hash.clone());
+        // migrate() clears the flag via complete_migration; call it directly
+        // rather than running the v1→v2 data migration against v2-shaped storage.
+        upgradeable::complete_migration(&env);
+    });
+
+    // With no migration pending, a follow-up upgrade must be accepted
+    env.as_contract(&contract_id, || {
+        <SmartAccount as SmartAccountUpgradeableMigratable>::upgrade(&env, v2_hash.clone());
+    });
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Fixes audit finding **LT-APP26-17**. `SmartAccount`'s hand-written `upgrade()` was missing the `ensure_no_pending_migration` guard that the `upgradeable` crate's trait default gained with the FIND-004 fix. An admin could call `upgrade()` a second time while `MIGRATING = true`, replacing the pending WASM before `migrate()` ran — the subsequent `migrate()` would then run the new WASM's migration logic against data never migrated through the intermediate version.

`upgrade()` now fails with `MigrationAlreadyPending` (#1110) while a migration is pending, matching the library default.

## Notes

- The contract keeps the manual `#[contractimpl]` block (rather than `impl_upgradeable_migratable!`) because Soroban's macro only exports functions written literally inside the block; the manual impl keeps the `UPGRADE_STARTED`/`UPGRADE_COMPLETED` events explicit.
- The new tests drive the **native** contract via `env.as_contract` instead of the `v2::Client`: `testdata/smart_account_v2.wasm` is a pre-built snapshot that predates current source (last rebuilt in #123), so a wasm-client test would exercise stale code, not this fix.

## Test plan

`cargo test -p smart-account upgrade` — 24 tests, 2 new:
- a second `upgrade()` while `MIGRATING = true` panics with #1110 (verified this fails without the guard),
- after the migration completes, a follow-up upgrade is accepted again.

Also clean: full `cargo test`, `cargo clippy --all-targets`, `cargo fmt`.