### PR TITLE
minor(smart-account): refresh spending tracker TTL on every check

### DIFF
--- a/contracts/smart-account-interfaces/src/auth/types.rs
+++ b/contracts/smart-account-interfaces/src/auth/types.rs
@@ -20,10 +20,10 @@ pub struct TokenTransferPolicy {
     ///
     /// Caveat: the spending tracker lives in Soroban persistent storage,
     /// which always has a finite TTL. The TTL is refreshed on every spending
-    /// check, but after ~30 days without one the entry is archived and the
-    /// cumulative total effectively resets to zero. To guarantee a lifetime
-    /// limit is never forgotten, keep the tracker entry alive externally
-    /// (e.g. a periodic ExtendFootprintTTLOp).
+    /// check but can still lapse after ~30 days without one, archiving the
+    /// entry. Since protocol 23 an archived entry is automatically restored
+    /// with its prior value on next access (paying restoration rent), so the
+    /// cumulative total survives; refreshing the TTL avoids that cost.
     pub reset_window_secs: u64,
     /// Allowed recipient addresses. None = any recipient is allowed; Some([]) = no recipient allowed (deny all).
     pub allowed_recipients: Option<Vec<Address>>,

--- a/contracts/smart-account-interfaces/src/auth/types.rs
+++ b/contracts/smart-account-interfaces/src/auth/types.rs
@@ -17,13 +17,8 @@ pub struct TokenTransferPolicy {
     /// None = no amount restriction; other checks (expiration, token, recipients) still apply.
     pub limit: Option<i128>,
     /// Number of seconds after which the spent amount resets. 0 = no reset (lifetime limit).
-    ///
-    /// Caveat: the spending tracker lives in Soroban persistent storage,
-    /// which always has a finite TTL. The TTL is refreshed on every spending
-    /// check but can still lapse after ~30 days without one, archiving the
-    /// entry. Since protocol 23 an archived entry is automatically restored
-    /// with its prior value on next access (paying restoration rent), so the
-    /// cumulative total survives; refreshing the TTL avoids that cost.
+    /// If the tracker's storage TTL lapses, the archived entry is auto-restored with its
+    /// prior value on next access (protocol >= 23), so the total survives archival.
     pub reset_window_secs: u64,
     /// Allowed recipient addresses. None = any recipient is allowed; Some([]) = no recipient allowed (deny all).
     pub allowed_recipients: Option<Vec<Address>>,

--- a/contracts/smart-account-interfaces/src/auth/types.rs
+++ b/contracts/smart-account-interfaces/src/auth/types.rs
@@ -17,6 +17,13 @@ pub struct TokenTransferPolicy {
     /// None = no amount restriction; other checks (expiration, token, recipients) still apply.
     pub limit: Option<i128>,
     /// Number of seconds after which the spent amount resets. 0 = no reset (lifetime limit).
+    ///
+    /// Caveat: the spending tracker lives in Soroban persistent storage,
+    /// which always has a finite TTL. The TTL is refreshed on every spending
+    /// check, but after ~30 days without one the entry is archived and the
+    /// cumulative total effectively resets to zero. To guarantee a lifetime
+    /// limit is never forgotten, keep the tracker entry alive externally
+    /// (e.g. a periodic ExtendFootprintTTLOp).
     pub reset_window_secs: u64,
     /// Allowed recipient addresses. None = any recipient is allowed; Some([]) = no recipient allowed (deny all).
     pub allowed_recipients: Option<Vec<Address>>,

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -14,12 +14,12 @@ use smart_account_interfaces::{
 /// Computes the TTL extend_to value for a spending tracker.
 /// Ensures the tracker stays live for at least one full spending window.
 ///
-/// Limitation: Soroban persistent entries always carry a finite TTL, so a
-/// lifetime limit (`reset_window_secs == 0`) is best-effort: if no policy
-/// check refreshes the tracker for PERSISTENT_EXTEND_TO (~30 days), the
-/// entry is archived and the next check starts over from `spent: 0`.
-/// Guaranteeing no reset requires keeping the entry alive externally
-/// (e.g. a periodic ExtendFootprintTTLOp on the tracker entry).
+/// Soroban persistent entries always carry a finite TTL, so the tracker is
+/// archived if no policy check refreshes it for PERSISTENT_EXTEND_TO
+/// (~30 days). Since protocol 23 archival is not data loss: the entry is
+/// auto-restored with its prior value on next access, at a restoration-rent
+/// cost. Refreshing the TTL on every check keeps that cost off the spend
+/// path; a periodic ExtendFootprintTTLOp does the same from outside.
 fn tracker_extend_to(reset_window_secs: u64) -> u32 {
     if reset_window_secs > 0 {
         let secs_per_ledger = 86400 / DAY_IN_LEDGERS as u64;

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -13,13 +13,6 @@ use smart_account_interfaces::{
 
 /// Computes the TTL extend_to value for a spending tracker.
 /// Ensures the tracker stays live for at least one full spending window.
-///
-/// Soroban persistent entries always carry a finite TTL, so the tracker is
-/// archived if no policy check refreshes it for PERSISTENT_EXTEND_TO
-/// (~30 days). Since protocol 23 archival is not data loss: the entry is
-/// auto-restored with its prior value on next access, at a restoration-rent
-/// cost. Refreshing the TTL on every check keeps that cost off the spend
-/// path; a periodic ExtendFootprintTTLOp does the same from outside.
 fn tracker_extend_to(reset_window_secs: u64) -> u32 {
     if reset_window_secs > 0 {
         let secs_per_ledger = 86400 / DAY_IN_LEDGERS as u64;
@@ -102,9 +95,7 @@ fn check_spending_limit(
     let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
     let stored: Option<SpendingTracker> = env.storage().persistent().get(&tracker_key);
 
-    // Refresh the TTL on every check, not just on recorded spends, so gaps
-    // without spending are less likely to archive the entry and silently
-    // reset the cumulative total (see tracker_extend_to).
+    // Refresh the TTL on every check, not just on recorded spends
     if stored.is_some() {
         env.storage().persistent().extend_ttl(
             &tracker_key,

--- a/contracts/smart-account/src/auth/policy/token_transfer.rs
+++ b/contracts/smart-account/src/auth/policy/token_transfer.rs
@@ -13,6 +13,13 @@ use smart_account_interfaces::{
 
 /// Computes the TTL extend_to value for a spending tracker.
 /// Ensures the tracker stays live for at least one full spending window.
+///
+/// Limitation: Soroban persistent entries always carry a finite TTL, so a
+/// lifetime limit (`reset_window_secs == 0`) is best-effort: if no policy
+/// check refreshes the tracker for PERSISTENT_EXTEND_TO (~30 days), the
+/// entry is archived and the next check starts over from `spent: 0`.
+/// Guaranteeing no reset requires keeping the entry alive externally
+/// (e.g. a periodic ExtendFootprintTTLOp on the tracker entry).
 fn tracker_extend_to(reset_window_secs: u64) -> u32 {
     if reset_window_secs > 0 {
         let secs_per_ledger = 86400 / DAY_IN_LEDGERS as u64;
@@ -93,14 +100,23 @@ fn check_spending_limit(
     let now = env.ledger().timestamp();
 
     let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
-    let mut tracker: SpendingTracker =
-        env.storage()
-            .persistent()
-            .get(&tracker_key)
-            .unwrap_or(SpendingTracker {
-                spent: 0,
-                window_start: now,
-            });
+    let stored: Option<SpendingTracker> = env.storage().persistent().get(&tracker_key);
+
+    // Refresh the TTL on every check, not just on recorded spends, so gaps
+    // without spending are less likely to archive the entry and silently
+    // reset the cumulative total (see tracker_extend_to).
+    if stored.is_some() {
+        env.storage().persistent().extend_ttl(
+            &tracker_key,
+            PERSISTENT_TTL_THRESHOLD,
+            tracker_extend_to(policy.reset_window_secs),
+        );
+    }
+
+    let mut tracker = stored.unwrap_or(SpendingTracker {
+        spent: 0,
+        window_start: now,
+    });
 
     // Check if the spending window should reset
     if policy.reset_window_secs > 0

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -962,8 +962,7 @@ fn test_tracker_ttl_refreshed_on_denied_check() {
         );
     });
 
-    // An over-limit check is denied and records no spend, but must still
-    // refresh the tracker TTL so inactivity doesn't archive the entry.
+    // A denied over-limit check records no spend but must still refresh the TTL
     let to = Address::generate(&env);
     let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1001)];
     env.as_contract(&contract_id, || {
@@ -1027,10 +1026,7 @@ fn test_windowed_tracker_ttl_covers_full_window() {
 
 #[test]
 fn test_missing_tracker_starts_spending_from_zero() {
-    // Pins the fallback: if the tracker entry is ever absent, the cumulative
-    // total starts over from zero. Archival cannot produce this state —
-    // persistent entries restore with their prior value — so in practice it
-    // takes an explicit removal.
+    // Only an explicit removal makes the tracker absent; spending then starts from zero
     let env = setup();
     let token = Address::generate(&env);
     let policy = make_policy(&env, &token, Some(1000));
@@ -1046,7 +1042,6 @@ fn test_missing_tracker_starts_spending_from_zero() {
     let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1)];
     check_auth(&env, &contract_id, &signer, &contexts).unwrap_err();
 
-    // Simulate archival of the tracker entry
     env.as_contract(&contract_id, || {
         env.storage().persistent().remove(&tracker_key);
     });
@@ -1058,13 +1053,8 @@ fn test_missing_tracker_starts_spending_from_zero() {
 
 #[test]
 fn test_expired_tracker_never_reads_as_reset() {
-    // A lapsed tracker TTL cannot reset the lifetime limit. On the live
-    // network (protocol >= 23) the archived entry is auto-restored with its
-    // prior value before execution (CAP-0066); the SDK test host doesn't
-    // model restoration and aborts the access instead. Under neither
-    // semantics does the entry read as absent, so the `unwrap_or(spent: 0)`
-    // fallback is unreachable through archival and the extra spend below can
-    // never be authorized.
+    // An expired entry never reads as absent: the live network auto-restores it
+    // with its prior value (protocol >= 23); the SDK test host aborts the access.
     let env = setup();
     let token = Address::generate(&env);
     let policy = make_policy(&env, &token, Some(1000)); // lifetime limit

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -928,3 +928,128 @@ fn test_updating_allowed_recipients_preserves_spending_tracker() {
     let contexts = vec![&env, make_transfer_context(&env, &token, &allowed_2, 300)];
     check_auth(&env, &contract_id, &signer, &contexts).unwrap();
 }
+
+// ============================================================================
+// Tracker TTL refresh tests
+// ============================================================================
+
+#[test]
+fn test_tracker_ttl_refreshed_on_denied_check() {
+    use crate::config::PERSISTENT_EXTEND_TO;
+    use soroban_sdk::testutils::storage::Persistent as _;
+
+    let env = setup();
+    let token = Address::generate(&env);
+    let policy = make_policy(&env, &token, Some(1000)); // reset_window_secs = 0 (lifetime)
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+    let signer_key = SignerKey::Ed25519(signer.public_key(&env));
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key.clone());
+
+    // on_add extends the tracker TTL to PERSISTENT_EXTEND_TO
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage().persistent().get_ttl(&tracker_key),
+            PERSISTENT_EXTEND_TO
+        );
+    });
+
+    // Let most of the TTL elapse (below PERSISTENT_TTL_THRESHOLD, entry still live)
+    env.ledger().with_mut(|li| li.sequence_number += 450_000);
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage().persistent().get_ttl(&tracker_key),
+            PERSISTENT_EXTEND_TO - 450_000
+        );
+    });
+
+    // An over-limit check is denied and records no spend, but must still
+    // refresh the tracker TTL so inactivity doesn't archive the entry.
+    let to = Address::generate(&env);
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1001)];
+    env.as_contract(&contract_id, || {
+        assert!(!policy.is_authorized(&env, &signer_key, &contexts));
+    });
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage().persistent().get_ttl(&tracker_key),
+            PERSISTENT_EXTEND_TO
+        );
+    });
+}
+
+#[test]
+fn test_tracker_ttl_refreshed_on_recorded_spend() {
+    use crate::config::PERSISTENT_EXTEND_TO;
+    use soroban_sdk::testutils::storage::Persistent as _;
+
+    let env = setup();
+    let token = Address::generate(&env);
+    let policy = make_policy(&env, &token, Some(1000));
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+    let signer_key = SignerKey::Ed25519(signer.public_key(&env));
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key);
+
+    // Let most of the TTL elapse, then perform an authorized transfer
+    env.ledger().with_mut(|li| li.sequence_number += 450_000);
+    let to = Address::generate(&env);
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 100)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap();
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage().persistent().get_ttl(&tracker_key),
+            PERSISTENT_EXTEND_TO
+        );
+    });
+}
+
+#[test]
+fn test_windowed_tracker_ttl_covers_full_window() {
+    use crate::config::{DAY_IN_LEDGERS, PERSISTENT_EXTEND_TO};
+    use soroban_sdk::testutils::storage::Persistent as _;
+
+    let env = setup();
+    let token = Address::generate(&env);
+    let mut policy = make_policy(&env, &token, Some(1000));
+    policy.reset_window_secs = 45 * 86_400; // 45-day window, longer than PERSISTENT_EXTEND_TO
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+    let signer_key = SignerKey::Ed25519(signer.public_key(&env));
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key);
+
+    // tracker_extend_to = window in ledgers + one day of margin
+    let expected = 45 * DAY_IN_LEDGERS + DAY_IN_LEDGERS;
+    assert!(expected > PERSISTENT_EXTEND_TO);
+    env.as_contract(&contract_id, || {
+        assert_eq!(env.storage().persistent().get_ttl(&tracker_key), expected);
+    });
+}
+
+#[test]
+fn test_archived_tracker_resets_lifetime_limit() {
+    // Pins the documented residual limitation: if the tracker entry is
+    // archived by TTL expiry, the cumulative total starts over from zero.
+    let env = setup();
+    let token = Address::generate(&env);
+    let policy = make_policy(&env, &token, Some(1000));
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+    let signer_key = SignerKey::Ed25519(signer.public_key(&env));
+    let tracker_key = SpendTrackerKey::TokenSpend(policy.policy_id.clone(), signer_key);
+
+    let to = Address::generate(&env);
+
+    // Exhaust the lifetime limit
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1000)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap();
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap_err();
+
+    // Simulate archival of the tracker entry
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&tracker_key);
+    });
+
+    // The limit is forgotten: the full amount can be spent again
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1000)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap();
+}

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -1027,9 +1027,10 @@ fn test_windowed_tracker_ttl_covers_full_window() {
 
 #[test]
 fn test_missing_tracker_starts_spending_from_zero() {
-    // Pins the fallback: if the tracker entry is ever absent (protocol >= 23
-    // auto-restores archived entries, so this needs an explicit removal or
-    // pre-23 semantics), the cumulative total starts over from zero.
+    // Pins the fallback: if the tracker entry is ever absent, the cumulative
+    // total starts over from zero. Archival cannot produce this state —
+    // persistent entries restore with their prior value — so in practice it
+    // takes an explicit removal.
     let env = setup();
     let token = Address::generate(&env);
     let policy = make_policy(&env, &token, Some(1000));

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -1026,9 +1026,10 @@ fn test_windowed_tracker_ttl_covers_full_window() {
 }
 
 #[test]
-fn test_archived_tracker_resets_lifetime_limit() {
-    // Pins the documented residual limitation: if the tracker entry is
-    // archived by TTL expiry, the cumulative total starts over from zero.
+fn test_missing_tracker_starts_spending_from_zero() {
+    // Pins the fallback: if the tracker entry is ever absent (protocol >= 23
+    // auto-restores archived entries, so this needs an explicit removal or
+    // pre-23 semantics), the cumulative total starts over from zero.
     let env = setup();
     let token = Address::generate(&env);
     let policy = make_policy(&env, &token, Some(1000));

--- a/contracts/smart-account/src/tests/token_transfer_policy_test.rs
+++ b/contracts/smart-account/src/tests/token_transfer_policy_test.rs
@@ -1055,3 +1055,44 @@ fn test_missing_tracker_starts_spending_from_zero() {
     let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1000)];
     check_auth(&env, &contract_id, &signer, &contexts).unwrap();
 }
+
+#[test]
+fn test_expired_tracker_never_reads_as_reset() {
+    // A lapsed tracker TTL cannot reset the lifetime limit. On the live
+    // network (protocol >= 23) the archived entry is auto-restored with its
+    // prior value before execution (CAP-0066); the SDK test host doesn't
+    // model restoration and aborts the access instead. Under neither
+    // semantics does the entry read as absent, so the `unwrap_or(spent: 0)`
+    // fallback is unreachable through archival and the extra spend below can
+    // never be authorized.
+    let env = setup();
+    let token = Address::generate(&env);
+    let policy = make_policy(&env, &token, Some(1000)); // lifetime limit
+    let (contract_id, signer) = setup_account_with_policy(&env, &policy);
+
+    let to = Address::generate(&env);
+
+    // Exhaust the lifetime limit
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1000)];
+    check_auth(&env, &contract_id, &signer, &contexts).unwrap();
+
+    // Let the tracker's TTL (PERSISTENT_EXTEND_TO = 518,400 ledgers) lapse
+    env.ledger().with_mut(|li| li.sequence_number += 600_000);
+
+    // Attempt to spend the full limit again: must not be authorized
+    let payload = BytesN::random(&env);
+    let (signer_key, proof) = signer.sign(&env, &payload);
+    let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
+    let contexts = vec![&env, make_transfer_context(&env, &token, &to, 1000)];
+    let res = env.try_invoke_contract_check_auth::<Error>(
+        &contract_id,
+        &payload,
+        auth_payloads.into_val(&env),
+        &contexts,
+    );
+    assert!(
+        res.is_err(),
+        "spend after tracker archival must not be authorized, got {:?}",
+        res
+    );
+}


### PR DESCRIPTION
## What

Addresses audit finding **LT-APP26-19**. The `TokenTransferPolicy` spending tracker's TTL was only extended when a spend was recorded, so for lifetime limits (`reset_window_secs = 0`) a signer with no transfers for ~30 days would get its tracker archived.

Since protocol 23 archival is not state loss — the entry is auto-restored with its prior value on next access (validated on-chain against a local network: after letting the tracker entry expire, the next spend resumed from the restored total instead of zero) — so the practical impact is restoration rent and post-idle transaction friction rather than the reset-to-zero the finding describes. The fix still applies the audit's recommendations:

- `check_spending_limit` now refreshes the tracker TTL on **every** check where the entry exists — including denied checks and checks where a different policy ends up authorizing the transaction — not just recorded spends.
- A short note on `reset_window_secs` (interfaces crate) documents the archival/restoration semantics.

## Notes

- `extend_ttl` is threshold-gated (writes only when remaining TTL < 7 days), so the per-check refresh costs nothing most of the time.
- A denied check that fails the whole transaction rolls back its TTL extension with it; the refresh pays off when the policy is evaluated inside an otherwise-successful transaction.

## Test plan

`cargo test -p smart-account token_transfer` — 44 tests, 5 new:
- a denied (over-limit) check refreshes the tracker TTL (verified this fails without the fix),
- a recorded spend refreshes the tracker TTL,
- windowed policies longer than 30 days get a TTL covering the full window,
- an expired tracker can never authorize extra spend (the entry never reads as absent),
- a missing tracker entry starts spending over from zero (pins the fallback; only reachable via explicit removal).

Also clean: full `cargo test`, `cargo clippy --all-targets`, `cargo fmt`.