### PR TITLE
test(smart-account): modernize test crypto — ed25519-dalek v2, drop rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "educe",
  "itertools 0.13.0",
  "num-bigint",
@@ -220,7 +220,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -242,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -306,15 +306,6 @@ name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -552,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -585,19 +576,6 @@ checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
@@ -605,7 +583,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -698,20 +676,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -762,20 +731,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
 ]
 
 [[package]]
@@ -785,21 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -808,11 +754,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -844,13 +790,13 @@ dependencies = [
  "base16ct",
  "base64ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "serde_json",
  "serdect",
@@ -935,7 +881,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1013,17 +959,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
@@ -1031,7 +966,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1042,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1149,7 +1084,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1544,7 +1479,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1613,7 +1548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1675,12 +1610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,7 +1633,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1753,7 +1682,7 @@ dependencies = [
  "log",
  "p256",
  "passkey-types",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1790,13 +1719,13 @@ dependencies = [
  "ciborium",
  "coset",
  "data-encoding",
- "getrandom 0.2.16",
+ "getrandom",
  "hmac",
  "indexmap 2.11.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "strum",
  "typeshare",
  "zeroize",
@@ -1951,36 +1880,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1990,16 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2008,16 +1905,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -2096,7 +1984,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2380,26 +2268,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2408,7 +2283,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -2430,18 +2305,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -2462,17 +2331,16 @@ version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
  "base64ct",
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek",
  "env_logger",
  "initializable",
  "log",
  "p256",
  "passkey",
- "rand 0.7.3",
  "serde",
  "serde-json-core",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smart-account-interfaces",
  "soroban-sdk",
  "stellar-strkey 0.0.13",
@@ -2561,12 +2429,12 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom 0.2.16",
+ "getrandom",
  "hex-literal",
  "hmac",
  "k256",
@@ -2574,10 +2442,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -2627,8 +2495,8 @@ dependencies = [
  "crate-git-revision 0.0.9",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
- "rand 0.8.5",
+ "ed25519-dalek",
+ "rand",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2652,7 +2520,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -2667,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca1e22ce713871c6f9d21a321051b58e53080629b6a5be1132cf11f42cca4d10"
 dependencies = [
  "base64 0.22.1",
- "sha2 0.10.9",
+ "sha2",
  "stellar-xdr 27.0.0",
  "thiserror",
  "wasmparser",
@@ -2682,7 +2550,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr 27.0.0",
  "syn",
@@ -2746,7 +2614,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",
  "termcolor",
@@ -2800,7 +2668,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "stellar-strkey 0.0.13",
 ]
 
@@ -2819,7 +2687,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "stellar-strkey 0.0.13",
 ]
 
@@ -3163,11 +3031,11 @@ name = "upgrade-wallet"
 version = "0.1.0"
 dependencies = [
  "clap",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "hex",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "stellar-rpc-client",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",
@@ -3230,12 +3098,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/contracts/smart-account/Cargo.toml
+++ b/contracts/smart-account/Cargo.toml
@@ -25,9 +25,8 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 passkey = "0.3"
 serde_json = "1.0"
 base64 = "0.22"
-ed25519-dalek = { version = "1" }
+ed25519-dalek = { version = "2" }
 stellar-strkey = { version = "0.0.13" }
-rand = "0.7.3"
 p256 = { version = "0.13", features = ["ecdsa"] }
 sha2 = "0.10"
 base64ct = "1.6"

--- a/contracts/smart-account/src/tests/expiring_signer_test.rs
+++ b/contracts/smart-account/src/tests/expiring_signer_test.rs
@@ -16,17 +16,13 @@ use smart_account_interfaces::{SignerKey, SignerRole, SmartAccountInterface as _
 
 extern crate std;
 
-use ed25519_dalek::Keypair;
-
 // ============================================================================
 // Helpers
 // ============================================================================
 
-/// Reconstruct an Ed25519TestSigner with the same keypair but a different role.
-/// Needed because `ed25519_dalek::Keypair` does not implement `Clone`.
+/// Reconstruct an Ed25519TestSigner with the same signing key but a different role.
 fn with_role(signer: &Ed25519TestSigner, role: SignerRole) -> Ed25519TestSigner {
-    let bytes = signer.0.to_bytes();
-    Ed25519TestSigner(Keypair::from_bytes(&bytes).unwrap(), role)
+    Ed25519TestSigner(signer.0.clone(), role)
 }
 
 /// Invoke `__check_auth` and return the result.

--- a/contracts/smart-account/src/tests/test_utils.rs
+++ b/contracts/smart-account/src/tests/test_utils.rs
@@ -5,10 +5,10 @@ extern crate std;
 
 use alloc::vec::Vec;
 
-use ed25519_dalek::Keypair;
 use ed25519_dalek::Signer as _;
-use rand::rngs::StdRng;
-use rand::SeedableRng as _;
+// Aliased: the secp256r1/WebAuthn test signers below import `p256::ecdsa::SigningKey`
+// under the bare name, so the ed25519 key type must not collide with it.
+use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use soroban_sdk::auth::Context;
 use soroban_sdk::BytesN;
 use soroban_sdk::Env;
@@ -54,18 +54,31 @@ pub trait TestSignerTrait {
 // Ed25519
 // ============================================================================
 
-pub struct Ed25519TestSigner(pub Keypair, pub SignerRole);
+pub struct Ed25519TestSigner(pub Ed25519SigningKey, pub SignerRole);
+
+/// Monotonic counter for deterministic, unique Ed25519 test keys (no `rand`).
+static ED25519_SEED_COUNTER: AtomicU32 = AtomicU32::new(1);
+
+/// Deterministically derive a unique Ed25519 signing key, mirroring the
+/// secp256r1 helper. Replaces `Keypair::generate(&mut StdRng)` so tests no
+/// longer depend on `rand` and are fully reproducible.
+pub fn generate_ed25519_signing_key() -> Ed25519SigningKey {
+    let seed = ED25519_SEED_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut sk_bytes = [0u8; 32];
+    sk_bytes[..4].copy_from_slice(&seed.to_be_bytes());
+    sk_bytes[31] = 1; // ensure non-zero
+    Ed25519SigningKey::from_bytes(&sk_bytes)
+}
 
 impl Ed25519TestSigner {
     pub fn public_key(&self, env: &Env) -> BytesN<32> {
-        let Ed25519TestSigner(keypair, _) = self;
-        BytesN::from_array(env, &keypair.public.to_bytes())
+        BytesN::from_array(env, &self.0.verifying_key().to_bytes())
     }
 }
 
 impl TestSignerTrait for Ed25519TestSigner {
     fn generate(role: SignerRole) -> Self {
-        Self(Keypair::generate(&mut StdRng::from_entropy()), role)
+        Self(generate_ed25519_signing_key(), role)
     }
 
     #[allow(clippy::wrong_self_convention)]
@@ -79,7 +92,8 @@ impl TestSignerTrait for Ed25519TestSigner {
         if signature_bytes.len() != 64 {
             panic!("Invalid signature length");
         }
-        let signer_key = SignerKey::Ed25519(BytesN::from_array(env, &self.0.public.to_bytes()));
+        let signer_key =
+            SignerKey::Ed25519(BytesN::from_array(env, &self.0.verifying_key().to_bytes()));
         let signature = SignerProof::Ed25519(BytesN::from_array(env, &signature_bytes));
         (signer_key, signature)
     }

--- a/contracts/smart-account/src/tests/upgrade_test.rs
+++ b/contracts/smart-account/src/tests/upgrade_test.rs
@@ -58,18 +58,16 @@ mod v2 {
 // Helper functions
 // ============================================================================
 
-/// Generate an Ed25519 keypair for test use.
-fn generate_ed25519_keypair() -> ed25519_dalek::Keypair {
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    ed25519_dalek::Keypair::generate(&mut StdRng::from_entropy())
+/// Generate a deterministic Ed25519 signing key for test use (no `rand`).
+fn generate_ed25519_keypair() -> ed25519_dalek::SigningKey {
+    crate::tests::test_utils::generate_ed25519_signing_key()
 }
 
 /// Deploy a v1 contract with a single Ed25519 admin signer.
 /// Returns (contract_address, keypair).
-fn deploy_v1_with_ed25519_admin(env: &Env) -> (Address, ed25519_dalek::Keypair) {
+fn deploy_v1_with_ed25519_admin(env: &Env) -> (Address, ed25519_dalek::SigningKey) {
     let keypair = generate_ed25519_keypair();
-    let pk = BytesN::from_array(env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(env, &keypair.verifying_key().to_bytes());
 
     let signer = v1::Signer::Ed25519(v1::Ed25519Signer { public_key: pk }, v1::SignerRole::Admin);
 
@@ -82,9 +80,9 @@ fn deploy_v1_with_ed25519_admin(env: &Env) -> (Address, ed25519_dalek::Keypair) 
 /// Returns (contract_address, admin_keypair, secp_key_id, secp_public_key_bytes).
 fn deploy_v1_with_secp256r1_signer(
     env: &Env,
-) -> (Address, ed25519_dalek::Keypair, [u8; 18], [u8; 65]) {
+) -> (Address, ed25519_dalek::SigningKey, [u8; 18], [u8; 65]) {
     let admin_keypair = generate_ed25519_keypair();
-    let admin_pk = BytesN::from_array(env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(env, &admin_keypair.verifying_key().to_bytes());
 
     let admin_signer = v1::Signer::Ed25519(
         v1::Ed25519Signer {
@@ -169,7 +167,7 @@ fn test_upgrade_ed25519_admin_preserved() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     // Verify signer exists on v1
     let v1_client = v1::Client::new(&env, &contract_id);
@@ -209,7 +207,7 @@ fn test_migrate_secp256r1_to_webauthn() {
     env.mock_all_auths();
 
     let (contract_id, admin_keypair, key_id, pk_bytes) = deploy_v1_with_secp256r1_signer(&env);
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     // Verify secp256r1 signer exists on v1
     let v1_client = v1::Client::new(&env, &contract_id);
@@ -269,7 +267,7 @@ fn test_upgrade_ed25519_only_account() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     // Upgrade
     let v1_client = v1::Client::new(&env, &contract_id);
@@ -299,7 +297,7 @@ fn test_migrate_without_upgrade_fails() {
 
     // Deploy v2 directly (no upgrade path)
     let keypair = generate_ed25519_keypair();
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     let signer = v2::Signer::Ed25519(v2::Ed25519Signer { public_key: pk }, v2::SignerRole::Admin);
 
@@ -326,7 +324,7 @@ fn test_migrate_cannot_run_twice() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     // Upgrade
     let v1_client = v1::Client::new(&env, &contract_id);
@@ -422,7 +420,7 @@ fn test_new_signer_types_after_upgrade() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     // Upgrade and migrate
     let v1_client = v1::Client::new(&env, &contract_id);
@@ -473,7 +471,7 @@ fn test_upgrade_preserves_admin_count() {
 
     let (contract_id, admin_keypair, _key_id, _pk_bytes) = deploy_v1_with_secp256r1_signer(&env);
 
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     // v1: two admin signers (Ed25519 + Secp256r1)
     // Upgrade to v2
@@ -518,10 +516,10 @@ fn test_migrate_ed25519_with_external_policy() {
     env.mock_all_auths();
 
     let admin_keypair = generate_ed25519_keypair();
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     let standard_keypair = generate_ed25519_keypair();
-    let standard_pk = BytesN::from_array(&env, &standard_keypair.public.to_bytes());
+    let standard_pk = BytesN::from_array(&env, &standard_keypair.verifying_key().to_bytes());
 
     // Deploy a mock policy contract so v1 constructor's `on_add` succeeds
     let policy_address = env.register(DummyExternalPolicy, ());
@@ -561,7 +559,7 @@ fn test_migrate_ed25519_with_external_policy() {
     // Migrate — ALL Standard signers need migration due to XDR layout change
     // (v1 Standard(Vec<...>) vs v2 Standard(Option<Vec<...>>, u64)). The admin is
     // also included to satisfy the admin-count invariant.
-    let admin_pk_bytes = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk_bytes = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
     let v2_client = v2::Client::new(&env, &contract_id);
     v2_client.migrate(&v2::MigrationData::V1ToV2(v2::V1ToV2MigrationData {
         signers_to_migrate: vec![
@@ -594,10 +592,10 @@ fn test_migrate_ed25519_with_time_window_policy() {
     env.mock_all_auths();
 
     let admin_keypair = generate_ed25519_keypair();
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     let standard_keypair = generate_ed25519_keypair();
-    let standard_pk = BytesN::from_array(&env, &standard_keypair.public.to_bytes());
+    let standard_pk = BytesN::from_array(&env, &standard_keypair.verifying_key().to_bytes());
 
     let admin_signer = v1::Signer::Ed25519(
         v1::Ed25519Signer {
@@ -636,7 +634,7 @@ fn test_migrate_ed25519_with_time_window_policy() {
     // Migrate — the Ed25519 standard signer with TimeWindowPolicy needs migration
     // because the TimeWindowPolicy variant no longer exists in v2. The admin is
     // included to satisfy the admin-count invariant.
-    let admin_pk_bytes = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk_bytes = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
     let v2_client = v2::Client::new(&env, &contract_id);
     v2_client.migrate(&v2::MigrationData::V1ToV2(v2::V1ToV2MigrationData {
         signers_to_migrate: vec![
@@ -690,9 +688,9 @@ impl DummyPlugin {
 
 /// Helper: deploy v1, upgrade to v2, and migrate.
 /// Returns (contract_id, admin_keypair, v2_client).
-fn upgrade_and_migrate(env: &Env) -> (Address, ed25519_dalek::Keypair, v2::Client<'_>) {
+fn upgrade_and_migrate(env: &Env) -> (Address, ed25519_dalek::SigningKey, v2::Client<'_>) {
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(env);
-    let pk = BytesN::from_array(env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(env, &keypair.verifying_key().to_bytes());
     let v1_client = v1::Client::new(env, &contract_id);
     let v2_hash = upload_v2_wasm(env);
     v1_client.upgrade(&v2_hash);
@@ -725,7 +723,7 @@ fn test_auth_ed25519_works_after_migration() {
 
     let signer_key = smart_account_interfaces::SignerKey::Ed25519(BytesN::from_array(
         &env,
-        &admin_keypair.public.to_bytes(),
+        &admin_keypair.verifying_key().to_bytes(),
     ));
     let proof = SignerProof::Ed25519(BytesN::from_array(&env, &signature_bytes));
     let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
@@ -753,7 +751,7 @@ fn test_add_and_revoke_signer_after_migration() {
 
     // Add a new standard signer
     let new_keypair = generate_ed25519_keypair();
-    let new_pk = BytesN::from_array(&env, &new_keypair.public.to_bytes());
+    let new_pk = BytesN::from_array(&env, &new_keypair.verifying_key().to_bytes());
     let new_signer = v2::Signer::Ed25519(
         v2::Ed25519Signer {
             public_key: new_pk.clone(),
@@ -782,11 +780,11 @@ fn test_update_signer_role_after_migration() {
     env.mock_all_auths();
 
     let (_contract_id, admin_keypair, v2_client) = upgrade_and_migrate(&env);
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     // Add a second admin so we can downgrade the first one
     let admin2_keypair = generate_ed25519_keypair();
-    let admin2_pk = BytesN::from_array(&env, &admin2_keypair.public.to_bytes());
+    let admin2_pk = BytesN::from_array(&env, &admin2_keypair.verifying_key().to_bytes());
     v2_client.add_signer(&v2::Signer::Ed25519(
         v2::Ed25519Signer {
             public_key: admin2_pk,
@@ -836,7 +834,7 @@ fn test_install_plugin_after_migration() {
     };
     let signer_key = smart_account_interfaces::SignerKey::Ed25519(BytesN::from_array(
         &env,
-        &admin_keypair.public.to_bytes(),
+        &admin_keypair.verifying_key().to_bytes(),
     ));
     let proof = SignerProof::Ed25519(BytesN::from_array(&env, &signature_bytes));
     let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
@@ -871,7 +869,7 @@ fn test_admin_protection_after_migration() {
     env.mock_all_auths();
 
     let (_contract_id, admin_keypair, v2_client) = upgrade_and_migrate(&env);
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     // Try to revoke the only admin — contract should reject this
     // revoke_signer returns a Result; on the v2::Client it panics on error
@@ -892,7 +890,7 @@ fn test_revoke_migrated_webauthn_standard_signer() {
     env.mock_all_auths();
 
     let admin_keypair = generate_ed25519_keypair();
-    let admin_pk = BytesN::from_array(&env, &admin_keypair.public.to_bytes());
+    let admin_pk = BytesN::from_array(&env, &admin_keypair.verifying_key().to_bytes());
 
     let admin_signer = v1::Signer::Ed25519(
         v1::Ed25519Signer {
@@ -991,7 +989,7 @@ fn test_auth_admin_can_authorize_upgrade_after_migration() {
 
     let signer_key = smart_account_interfaces::SignerKey::Ed25519(BytesN::from_array(
         &env,
-        &admin_keypair.public.to_bytes(),
+        &admin_keypair.verifying_key().to_bytes(),
     ));
     let proof = SignerProof::Ed25519(BytesN::from_array(&env, &signature_bytes));
     let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
@@ -1023,7 +1021,7 @@ fn test_auth_standard_cannot_authorize_upgrade_after_migration() {
 
     // Add a standard signer
     let standard_keypair = generate_ed25519_keypair();
-    let standard_pk = BytesN::from_array(&env, &standard_keypair.public.to_bytes());
+    let standard_pk = BytesN::from_array(&env, &standard_keypair.verifying_key().to_bytes());
     let standard_signer = v2::Signer::Ed25519(
         v2::Ed25519Signer {
             public_key: standard_pk.clone(),
@@ -1084,7 +1082,7 @@ fn test_auth_admin_can_authorize_migrate_after_migration() {
 
     let signer_key = smart_account_interfaces::SignerKey::Ed25519(BytesN::from_array(
         &env,
-        &admin_keypair.public.to_bytes(),
+        &admin_keypair.verifying_key().to_bytes(),
     ));
     let proof = SignerProof::Ed25519(BytesN::from_array(&env, &signature_bytes));
     let auth_payloads = SignatureProofs(map![&env, (signer_key, proof)]);
@@ -1120,7 +1118,7 @@ fn test_auth_standard_cannot_authorize_migrate_after_migration() {
 
     // Add a standard signer
     let standard_keypair = generate_ed25519_keypair();
-    let standard_pk = BytesN::from_array(&env, &standard_keypair.public.to_bytes());
+    let standard_pk = BytesN::from_array(&env, &standard_keypair.verifying_key().to_bytes());
     let standard_signer = v2::Signer::Ed25519(
         v2::Ed25519Signer {
             public_key: standard_pk.clone(),
@@ -1180,7 +1178,7 @@ fn test_migrate_rejects_wrong_expected_signer_count() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     let v1_client = v1::Client::new(&env, &contract_id);
     let v2_hash = upload_v2_wasm(&env);
@@ -1206,7 +1204,7 @@ fn test_migrate_rejects_wrong_expected_admin_count_vs_stored() {
     env.mock_all_auths();
 
     let (contract_id, keypair) = deploy_v1_with_ed25519_admin(&env);
-    let pk = BytesN::from_array(&env, &keypair.public.to_bytes());
+    let pk = BytesN::from_array(&env, &keypair.verifying_key().to_bytes());
 
     let v1_client = v1::Client::new(&env, &contract_id);
     let v2_hash = upload_v2_wasm(&env);


### PR DESCRIPTION
## What

Modernizes the ed25519 test-signing crypto: upgrades `ed25519-dalek` 1 → 2 and drops the direct `rand` dependency. **Test-only; no production code changes.**

Stacked on #131 (the soroban-sdk 27 bump).

## Why

Investigating whether the `ed25519-dalek` / `rand` test deps could be swapped for native Stellar libraries:

- **`ed25519-dalek` can't be replaced by a native SDK helper.** soroban-sdk's `testutils::ed25519::Sign` is implemented *on top of* `ed25519-dalek` and signs an *ScVal-encoded* message, whereas the wallet's signers verify a raw 32-byte payload hash — so it doesn't fit our path. `ed25519-dalek` is also already pulled in transitively by `soroban-sdk[testutils]`, so moving to v2 dedupes the tree (v1 is EOL).
- **`rand` can go.** Ed25519 keys are now derived deterministically (a per-key counter → `SigningKey::from_bytes`), mirroring the existing secp256r1 test signer. Bonus: reproducible tests.

## Changes

- `ed25519-dalek = "2"`, remove `rand = "0.7.3"` from smart-account dev-deps.
- A shared `generate_ed25519_signing_key()` in `test_utils` hands out globally unique, deterministic keys.
- v2 API: `Keypair` → `SigningKey`, `keypair.public` → `verifying_key()`. The ed25519 key type is aliased `Ed25519SigningKey` so it doesn't collide with the p256 `SigningKey` used by the secp256r1 / WebAuthn signers.
- `expiring_signer_test::with_role` collapses to a plain `.clone()` (v2 `SigningKey: Clone`).

## Verification

- `cargo test --workspace` — all pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
