### PR TITLE
refactor(events): migrate Events::publish to #[contractevent]

### DIFF
--- a/contracts/contract-factory/src/lib.rs
+++ b/contracts/contract-factory/src/lib.rs
@@ -1,12 +1,8 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, xdr::ToXdr, Address, Bytes, BytesN,
-    Env, Symbol, Val, Vec,
+    contract, contractevent, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    Symbol, Val, Vec,
 };
-
-const DEPLOYED_CONTRACT: Symbol = symbol_short!("DEPLOYED");
 
 const DAY_IN_LEDGERS: u32 = 17_280;
 const INSTANCE_TTL_THRESHOLD: u32 = 7 * DAY_IN_LEDGERS;
@@ -31,7 +27,7 @@ pub struct ContractCall {
     pub func: Symbol,
 }
 
-#[contracttype]
+#[contractevent(topics = ["DEPLOYED"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractDeployedEvent {
     contract_id: Address,
@@ -74,15 +70,10 @@ impl ContractFactory {
             .with_current_contract(derived_salt)
             .deploy_v2(wasm_hash, constructor_args);
 
-        env.events().publish(
-            vec![env, DEPLOYED_CONTRACT],
-            vec![
-                env,
-                ContractDeployedEvent {
-                    contract_id: contract_id.clone(),
-                },
-            ],
-        );
+        ContractDeployedEvent {
+            contract_id: contract_id.clone(),
+        }
+        .publish(env);
         contract_id
     }
 

--- a/contracts/examples/plugin-policy-example/src/lib.rs
+++ b/contracts/examples/plugin-policy-example/src/lib.rs
@@ -1,10 +1,8 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 use smart_account_interfaces::{PolicyError, SignerKey, SmartAccountPlugin, SmartAccountPolicy};
 use soroban_sdk::{
     auth::{Context, ContractContext},
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, TryFromVal, Vec,
+    contract, contractevent, contractimpl, symbol_short, Address, Env, Symbol, TryFromVal, Vec,
 };
 
 const AUTH_COUNTER_KEY: Symbol = symbol_short!("COUNTER");
@@ -12,17 +10,28 @@ const AUTH_COUNTER_KEY: Symbol = symbol_short!("COUNTER");
 #[contract]
 pub struct PluginPolicyContract;
 
-#[contracttype]
+#[contractevent(topics = ["AUTH"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuthEvent {
+    #[topic]
     pub source: Address,
     pub context_count: u32,
     pub counter: u32,
 }
 
-#[contracttype]
+#[contractevent(topics = ["POL_AUTH"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyAuthEvent {
+    #[topic]
+    pub source: Address,
+    pub context_count: u32,
+    pub counter: u32,
+}
+
+#[contractevent(topics = ["DENY"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferDeniedEvent {
+    #[topic]
     pub source: Address,
     pub amount: i128,
     pub limit: i128,
@@ -49,14 +58,12 @@ impl SmartAccountPlugin for PluginPolicyContract {
             .set(&AUTH_COUNTER_KEY, &new_counter);
 
         // Emit an event
-        env.events().publish(
-            (symbol_short!("AUTH"), &source),
-            AuthEvent {
-                source: source.clone(),
-                context_count: contexts.len(),
-                counter: new_counter,
-            },
-        );
+        AuthEvent {
+            source: source.clone(),
+            context_count: contexts.len(),
+            counter: new_counter,
+        }
+        .publish(env);
     }
 }
 
@@ -87,14 +94,12 @@ impl SmartAccountPolicy for PluginPolicyContract {
             .set(&AUTH_COUNTER_KEY, &new_counter);
 
         // Emit an event with the current counter
-        env.events().publish(
-            (symbol_short!("POL_AUTH"), &source),
-            AuthEvent {
-                source: source.clone(),
-                context_count: contexts.len(),
-                counter: new_counter,
-            },
-        );
+        PolicyAuthEvent {
+            source: source.clone(),
+            context_count: contexts.len(),
+            counter: new_counter,
+        }
+        .publish(env);
 
         const TRANSFER_LIMIT: i128 = 100;
 
@@ -107,14 +112,12 @@ impl SmartAccountPolicy for PluginPolicyContract {
                 if fn_name == symbol_short!("transfer") && args.len() >= 3 {
                     if let Ok(amount) = i128::try_from_val(env, &args.get(2).unwrap()) {
                         if amount > TRANSFER_LIMIT {
-                            env.events().publish(
-                                (symbol_short!("DENY"), &source),
-                                TransferDeniedEvent {
-                                    source: source.clone(),
-                                    amount,
-                                    limit: TRANSFER_LIMIT,
-                                },
-                            );
+                            TransferDeniedEvent {
+                                source: source.clone(),
+                                amount,
+                                limit: TRANSFER_LIMIT,
+                            }
+                            .publish(env);
                             return Err(PolicyError::Unknown);
                         }
                     }

--- a/contracts/examples/withdraw-proxy/src/lib.rs
+++ b/contracts/examples/withdraw-proxy/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 
 //! # Withdraw Proxy
 //!
@@ -15,8 +13,8 @@
 //! approvals, so it can never move funds the caller did not authorize.
 
 use soroban_sdk::{
-    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
-    Env, Symbol,
+    contract, contractclient, contracterror, contractevent, contractimpl, contracttype, token,
+    Address, BytesN, Env,
 };
 
 /// Token precision the proxy supports, asserted on-chain. All amounts are token smallest units.
@@ -64,6 +62,18 @@ pub trait Coordinator {
         signature: BytesN<64>,
         public_key: BytesN<32>,
     );
+}
+
+/// Emitted on a successful atomic withdraw-then-transfer. Topics are
+/// `["withdraw_and_transfer", <caller>]`; the data is the vec
+/// `[recipient, withdraw_amount, transfer_amount]`.
+#[contractevent(topics = ["withdraw_and_transfer"], data_format = "vec")]
+pub struct WithdrawAndTransferEvent {
+    #[topic]
+    pub caller: Address,
+    pub recipient: Address,
+    pub withdraw_amount: i128,
+    pub transfer_amount: i128,
 }
 
 #[contract]
@@ -121,10 +131,13 @@ impl WithdrawProxy {
 
         token_client.transfer(&caller, &recipient, &transfer_amount);
 
-        env.events().publish(
-            (Symbol::new(&env, "withdraw_and_transfer"), caller),
-            (recipient, withdraw_amount, transfer_amount),
-        );
+        WithdrawAndTransferEvent {
+            caller,
+            recipient,
+            withdraw_amount,
+            transfer_amount,
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/contracts/initializable/src/lib.rs
+++ b/contracts/initializable/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 
-use soroban_sdk::{contracterror, symbol_short, Env, Symbol};
+use soroban_sdk::{contracterror, contractevent, symbol_short, Address, Env, Symbol};
 
 #[contracterror(export = false)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -13,6 +11,14 @@ pub enum Error {
 }
 
 const INITIALIZED: Symbol = symbol_short!("INIT");
+
+/// Emitted once when a contract is initialized. The data is the initialized
+/// contract's own address.
+#[contractevent(topics = ["INITIALIZED"], data_format = "single-value")]
+#[derive(Clone)]
+pub struct InitializedEvent {
+    pub contract: Address,
+}
 
 /// Macro to ensure a function only runs if the contract is initialized
 /// Usage: only_initialized!(env);
@@ -71,10 +77,10 @@ pub trait Initializable {
             return Err(Error::AlreadyInitialized);
         }
         Self::set_initialization_value(env, true);
-        env.events().publish(
-            (Symbol::new(env, "INITIALIZED"),),
-            env.current_contract_address(),
-        );
+        InitializedEvent {
+            contract: env.current_contract_address(),
+        }
+        .publish(env);
         Ok(())
     }
 

--- a/contracts/smart-account/src/account.rs
+++ b/contracts/smart-account/src/account.rs
@@ -4,13 +4,12 @@ use crate::auth::proof::SignatureProofs;
 use crate::config::{
     ADMIN_COUNT_KEY, CONTRACT_VERSION_KEY, CURRENT_CONTRACT_VERSION, INSTANCE_EXTEND_TO,
     INSTANCE_TTL_THRESHOLD, MAX_PLUGINS, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD,
-    PLUGINS_KEY, TOPIC_PLUGIN, TOPIC_SIGNER, VERB_ADDED, VERB_INSTALLED, VERB_REVOKED,
-    VERB_UNINSTALLED, VERB_UNINSTALL_FAILED, VERB_UPDATED,
+    PLUGINS_KEY,
 };
 use crate::error::Error;
 use crate::events::{
     PluginInstalledEvent, PluginUninstallFailedEvent, PluginUninstalledEvent, SignerAddedEvent,
-    SignerRevokedEvent, SignerUpdatedEvent,
+    SignerRevokedEvent, SignerUpdatedEvent, UpgradeCompletedEvent, UpgradeStartedEvent,
 };
 use crate::handle_nested_result_failure;
 use crate::migration::{run_migration, MigrationData};
@@ -66,10 +65,10 @@ impl SmartAccountUpgradeableMigratable for SmartAccount {
         Self::_require_auth_upgrade(e);
         upgradeable::ensure_no_pending_migration(e);
         upgradeable::enable_migration(e);
-        e.events().publish(
-            (Symbol::new(e, "UPGRADE_STARTED"),),
-            e.current_contract_address(),
-        );
+        UpgradeStartedEvent {
+            contract: e.current_contract_address(),
+        }
+        .publish(e);
         e.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 
@@ -78,10 +77,10 @@ impl SmartAccountUpgradeableMigratable for SmartAccount {
         upgradeable::ensure_can_complete_migration(e);
         Self::_migrate(e, &migration_data);
         upgradeable::complete_migration(e);
-        e.events().publish(
-            (Symbol::new(e, "UPGRADE_COMPLETED"),),
-            e.current_contract_address(),
-        );
+        UpgradeCompletedEvent {
+            contract: e.current_contract_address(),
+        }
+        .publish(e);
     }
 }
 
@@ -175,8 +174,7 @@ impl SmartAccountInterface for SmartAccount {
                 Self::increment_admin_count(env)?;
             }
         }
-        env.events()
-            .publish((TOPIC_SIGNER, VERB_ADDED), SignerAddedEvent::from(signer));
+        SignerAddedEvent::from(signer).publish(env);
 
         Ok(())
     }
@@ -208,10 +206,7 @@ impl SmartAccountInterface for SmartAccount {
         // Update the signer in storage
         storage.update::<SignerKey, Signer>(env, &key, &signer)?;
         storage.extend_ttl(env, &key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_EXTEND_TO);
-        env.events().publish(
-            (TOPIC_SIGNER, VERB_UPDATED),
-            SignerUpdatedEvent::from(signer),
-        );
+        SignerUpdatedEvent::from(signer).publish(env);
 
         Ok(())
     }
@@ -234,10 +229,7 @@ impl SmartAccountInterface for SmartAccount {
         if let SignerRole::Standard(policies, _) = signer_to_revoke.role() {
             Self::deactivate_policies(env, &signer_key, &policies)?;
         }
-        env.events().publish(
-            (TOPIC_SIGNER, VERB_REVOKED),
-            SignerRevokedEvent::from(signer_to_revoke),
-        );
+        SignerRevokedEvent::from(signer_to_revoke).publish(env);
         Ok(())
     }
 
@@ -274,10 +266,7 @@ impl SmartAccountInterface for SmartAccount {
             .map_err(|_| SmartAccountError::PluginInitializationFailed)?
             .map_err(|_| SmartAccountError::PluginInitializationFailed)?;
 
-        env.events().publish(
-            (TOPIC_PLUGIN, VERB_INSTALLED),
-            PluginInstalledEvent { plugin },
-        );
+        PluginInstalledEvent { plugin }.publish(env);
 
         Ok(())
     }
@@ -301,18 +290,13 @@ impl SmartAccountInterface for SmartAccount {
         let res = SmartAccountPluginClient::new(env, &plugin)
             .try_on_uninstall(&env.current_contract_address());
         handle_nested_result_failure!(res, {
-            env.events().publish(
-                (TOPIC_PLUGIN, VERB_UNINSTALL_FAILED),
-                PluginUninstallFailedEvent {
-                    plugin: plugin.clone(),
-                },
-            );
+            PluginUninstallFailedEvent {
+                plugin: plugin.clone(),
+            }
+            .publish(env);
         });
 
-        env.events().publish(
-            (TOPIC_PLUGIN, VERB_UNINSTALLED),
-            PluginUninstalledEvent { plugin },
-        );
+        PluginUninstalledEvent { plugin }.publish(env);
 
         Ok(())
     }

--- a/contracts/smart-account/src/auth/core/authorizer.rs
+++ b/contracts/smart-account/src/auth/core/authorizer.rs
@@ -2,10 +2,7 @@
 use crate::auth::permissions::AuthorizationCheck;
 use crate::auth::proof::SignatureProofs;
 use crate::auth::signers::SignatureVerifier as _;
-use crate::config::{
-    ADMIN_COUNT_KEY, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD, PLUGINS_KEY, TOPIC_PLUGIN,
-    VERB_AUTH_FAILED,
-};
+use crate::config::{ADMIN_COUNT_KEY, PERSISTENT_EXTEND_TO, PERSISTENT_TTL_THRESHOLD, PLUGINS_KEY};
 use crate::error::Error;
 use crate::events::PluginAuthFailedEvent;
 use smart_account_interfaces::SmartAccountPluginClient;
@@ -97,35 +94,29 @@ impl Authorizer {
                 // Plugin return value conversion failure (ABI mismatch)
                 // Treat as technical failure: log and continue
                 Ok(Err(_)) => {
-                    env.events().publish(
-                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
-                        PluginAuthFailedEvent {
-                            plugin: plugin.clone(),
-                            error: String::from_str(env, "Plugin return type mismatch (skipped)"),
-                        },
-                    );
+                    PluginAuthFailedEvent {
+                        plugin: plugin.clone(),
+                        error: String::from_str(env, "Plugin return type mismatch (skipped)"),
+                    }
+                    .publish(env);
                 }
                 // Plugin intentionally rejected (contracterror / panic_with_error!)
                 Err(Ok(_)) => {
-                    env.events().publish(
-                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
-                        PluginAuthFailedEvent {
-                            plugin: plugin.clone(),
-                            error: String::from_str(env, "Plugin rejected authorization"),
-                        },
-                    );
+                    PluginAuthFailedEvent {
+                        plugin: plugin.clone(),
+                        error: String::from_str(env, "Plugin rejected authorization"),
+                    }
+                    .publish(env);
                     return Err(Error::PluginOnAuthFailed);
                 }
                 // Plugin had a technical failure (panic!, host trap, TTL expiry)
                 // Non-blocking: log and continue to next plugin
                 Err(Err(_)) => {
-                    env.events().publish(
-                        (TOPIC_PLUGIN, &plugin, VERB_AUTH_FAILED),
-                        PluginAuthFailedEvent {
-                            plugin: plugin.clone(),
-                            error: String::from_str(env, "Plugin technical failure (skipped)"),
-                        },
-                    );
+                    PluginAuthFailedEvent {
+                        plugin: plugin.clone(),
+                        error: String::from_str(env, "Plugin technical failure (skipped)"),
+                    }
+                    .publish(env);
                 }
             }
         }

--- a/contracts/smart-account/src/auth/policy/external.rs
+++ b/contracts/smart-account/src/auth/policy/external.rs
@@ -2,7 +2,6 @@ use soroban_sdk::{auth::Context, Env, Vec};
 
 use crate::{
     auth::permissions::{AuthorizationCheck, PolicyCallback},
-    config::{TOPIC_POLICY, VERB_CALLBACK_FAILED},
     events::PolicyCallbackFailedEvent,
 };
 use smart_account_interfaces::{
@@ -28,12 +27,10 @@ impl AuthorizationCheck for ExternalPolicy {
             Ok(Ok(())) => true,
             Err(Ok(_)) => false,
             Ok(Err(_)) | Err(Err(_)) => {
-                env.events().publish(
-                    (TOPIC_POLICY, VERB_CALLBACK_FAILED),
-                    PolicyCallbackFailedEvent {
-                        policy_address: self.policy_address.clone(),
-                    },
-                );
+                PolicyCallbackFailedEvent {
+                    policy_address: self.policy_address.clone(),
+                }
+                .publish(env);
                 false
             }
         }
@@ -47,12 +44,10 @@ impl PolicyCallback for ExternalPolicy {
         match client.try_on_add(&wallet, signer_key) {
             Ok(Ok(())) => Ok(()),
             _ => {
-                env.events().publish(
-                    (TOPIC_POLICY, VERB_CALLBACK_FAILED),
-                    PolicyCallbackFailedEvent {
-                        policy_address: self.policy_address.clone(),
-                    },
-                );
+                PolicyCallbackFailedEvent {
+                    policy_address: self.policy_address.clone(),
+                }
+                .publish(env);
                 Err(SmartAccountError::PolicyClientInitializationError)
             }
         }
@@ -70,12 +65,10 @@ impl PolicyCallback for ExternalPolicy {
             // Non-blocking: an admin must always be able to revoke a misbehaving
             // permission contract, even if the external rejects the callback.
             _ => {
-                env.events().publish(
-                    (TOPIC_POLICY, VERB_CALLBACK_FAILED),
-                    PolicyCallbackFailedEvent {
-                        policy_address: self.policy_address.clone(),
-                    },
-                );
+                PolicyCallbackFailedEvent {
+                    policy_address: self.policy_address.clone(),
+                }
+                .publish(env);
             }
         }
         Ok(())

--- a/contracts/smart-account/src/events.rs
+++ b/contracts/smart-account/src/events.rs
@@ -1,7 +1,7 @@
 use smart_account_interfaces::{Signer, SignerKey};
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contractevent, Address, String};
 
-#[contracttype]
+#[contractevent(topics = ["signer", "added"])]
 #[derive(Clone)]
 pub struct SignerAddedEvent {
     pub signer_key: SignerKey,
@@ -17,7 +17,7 @@ impl From<Signer> for SignerAddedEvent {
     }
 }
 
-#[contracttype]
+#[contractevent(topics = ["signer", "updated"])]
 #[derive(Clone)]
 pub struct SignerUpdatedEvent {
     pub signer_key: SignerKey,
@@ -33,7 +33,7 @@ impl From<Signer> for SignerUpdatedEvent {
     }
 }
 
-#[contracttype]
+#[contractevent(topics = ["signer", "revoked"])]
 #[derive(Clone)]
 pub struct SignerRevokedEvent {
     pub signer_key: SignerKey,
@@ -49,33 +49,48 @@ impl From<Signer> for SignerRevokedEvent {
     }
 }
 
-#[contracttype]
+#[contractevent(topics = ["plugin", "installed"])]
 #[derive(Clone)]
 pub struct PluginInstalledEvent {
     pub plugin: Address,
 }
 
-#[contracttype]
+#[contractevent(topics = ["plugin", "uninst"])]
 #[derive(Clone)]
 pub struct PluginUninstalledEvent {
     pub plugin: Address,
 }
 
-#[contracttype]
+#[contractevent(topics = ["plugin", "uninsterr"])]
 #[derive(Clone)]
 pub struct PluginUninstallFailedEvent {
     pub plugin: Address,
 }
 
-#[contracttype]
+#[contractevent(topics = ["plugin", "autherr"])]
 #[derive(Clone)]
 pub struct PluginAuthFailedEvent {
+    #[topic]
     pub plugin: Address,
     pub error: String,
 }
 
-#[contracttype]
+#[contractevent(topics = ["policy", "cbfailed"])]
 #[derive(Clone)]
 pub struct PolicyCallbackFailedEvent {
     pub policy_address: Address,
+}
+
+/// Emitted when a two-phase upgrade begins; data is the contract's own address.
+#[contractevent(topics = ["UPGRADE_STARTED"], data_format = "single-value")]
+#[derive(Clone)]
+pub struct UpgradeStartedEvent {
+    pub contract: Address,
+}
+
+/// Emitted when a two-phase upgrade completes; data is the contract's own address.
+#[contractevent(topics = ["UPGRADE_COMPLETED"], data_format = "single-value")]
+#[derive(Clone)]
+pub struct UpgradeCompletedEvent {
+    pub contract: Address,
 }

--- a/contracts/smart-account/src/lib.rs
+++ b/contracts/smart-account/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 
 pub mod account;
 pub mod auth;

--- a/contracts/smart-account/src/tests/external_policy_test.rs
+++ b/contracts/smart-account/src/tests/external_policy_test.rs
@@ -4,13 +4,12 @@ use soroban_sdk::auth::{Context, ContractContext};
 use soroban_sdk::testutils::{Address as _, BytesN as _, Events, Ledger as _};
 use soroban_sdk::{
     contract, contractimpl, contracttype, map, symbol_short, vec, Address, BytesN, Env, IntoVal,
-    Symbol, TryFromVal, Val, Vec,
+    Map, Symbol, TryFromVal, Val, Vec,
 };
 
 use crate::account::SmartAccount;
 use crate::auth::proof::SignatureProofs;
 use crate::error::Error;
-use crate::events::PolicyCallbackFailedEvent;
 use crate::tests::test_utils::{
     get_token_auth_context, setup, Ed25519TestSigner, TestSignerTrait as _,
 };
@@ -179,7 +178,12 @@ fn callback_failed_event_count(env: &Env, expected: &Address) -> u32 {
     // exposes the raw `xdr::ContractEvent`s. Bind it to a local so the borrowed
     // slice outlives the loop, then convert each ScVal topic/data back to a
     // `Val` to preserve the original topic + payload filter.
+    //
+    // The `PolicyCallbackFailedEvent` is now a `#[contractevent]` whose data
+    // body is the sorted map `{policy_address: <addr>}`, so we read the address
+    // back out of that map rather than deserializing the whole struct.
     let target = symbol_short!("cbfailed");
+    let policy_address_key = Symbol::new(env, "policy_address");
     let all = env.events().all();
     let mut count = 0u32;
     for event in all.events() {
@@ -197,8 +201,10 @@ fn callback_failed_event_count(env: &Env, expected: &Address) -> u32 {
         }
 
         if let Ok(data) = Val::try_from_val(env, &body.data) {
-            if PolicyCallbackFailedEvent::try_from_val(env, &data)
-                .map(|e| &e.policy_address == expected)
+            if Map::<Symbol, Address>::try_from_val(env, &data)
+                .ok()
+                .and_then(|m| m.get(policy_address_key.clone()))
+                .map(|addr| &addr == expected)
                 .unwrap_or(false)
             {
                 count += 1;

--- a/contracts/storage/src/lib.rs
+++ b/contracts/storage/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 
-use soroban_sdk::{contracttype, symbol_short, Env, IntoVal, TryFromVal, Val};
+use soroban_sdk::{contractevent, contracttype, Env, IntoVal, TryFromVal, Val};
 
 #[derive(Debug)]
 pub enum Error {
@@ -25,9 +23,32 @@ pub enum StorageOperation {
     Delete,
 }
 
-#[contracttype]
+/// Emitted when a value is first stored under a key.
+///
+/// Carries the same `{storage_type, operation}` data body as the update and
+/// delete events so the on-chain payload is uniform across storage mutations;
+/// the operation is always [`StorageOperation::Store`] here.
+#[contractevent(topics = ["storage", "store"])]
 #[derive(Clone)]
-pub struct StorageChangeEvent {
+pub struct StorageStoredEvent {
+    pub storage_type: StorageType,
+    pub operation: StorageOperation,
+}
+
+/// Emitted when an existing value is updated. The operation is always
+/// [`StorageOperation::Update`].
+#[contractevent(topics = ["storage", "update"])]
+#[derive(Clone)]
+pub struct StorageUpdatedEvent {
+    pub storage_type: StorageType,
+    pub operation: StorageOperation,
+}
+
+/// Emitted when a value is deleted. The operation is always
+/// [`StorageOperation::Delete`].
+#[contractevent(topics = ["storage", "delete"])]
+#[derive(Clone)]
+pub struct StorageDeletedEvent {
     pub storage_type: StorageType,
     pub operation: StorageOperation,
 }
@@ -104,12 +125,11 @@ impl Storage {
 
         match result {
             Ok(_) => {
-                let event = StorageChangeEvent {
+                StorageStoredEvent {
                     storage_type: self.storage_type.clone(),
                     operation: StorageOperation::Store,
-                };
-                env.events()
-                    .publish((symbol_short!("storage"), symbol_short!("store")), event);
+                }
+                .publish(env);
                 Ok(())
             }
             Err(e) => Err(e),
@@ -149,12 +169,11 @@ impl Storage {
 
         match result {
             Ok(_) => {
-                let event = StorageChangeEvent {
+                StorageUpdatedEvent {
                     storage_type: self.storage_type.clone(),
                     operation: StorageOperation::Update,
-                };
-                env.events()
-                    .publish((symbol_short!("storage"), symbol_short!("update")), event);
+                }
+                .publish(env);
                 Ok(())
             }
             Err(e) => Err(e),
@@ -177,12 +196,11 @@ impl Storage {
             }
         }
 
-        let event = StorageChangeEvent {
+        StorageDeletedEvent {
             storage_type: self.storage_type.clone(),
             operation: StorageOperation::Delete,
-        };
-        env.events()
-            .publish((symbol_short!("storage"), symbol_short!("delete")), event);
+        }
+        .publish(env);
 
         Ok(())
     }

--- a/contracts/upgradeable/src/lib.rs
+++ b/contracts/upgradeable/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
-// Deprecated in soroban-sdk 23+; `#[contractevent]` migration is deferred (changes event topic layout).
-#![allow(deprecated)]
 
 use soroban_sdk::{
-    contracterror, panic_with_error, symbol_short, BytesN, Env, FromVal, Symbol, Val,
+    contracterror, contractevent, panic_with_error, symbol_short, Address, BytesN, Env, FromVal,
+    Symbol, Val,
 };
 
 #[contracterror(export = false)]
@@ -15,6 +14,22 @@ pub enum Error {
 }
 
 pub const MIGRATING: Symbol = symbol_short!("MIGRATING");
+
+/// Emitted when a two-phase upgrade begins (WASM swap). The data is the
+/// upgrading contract's own address.
+#[contractevent(topics = ["UPGRADE_STARTED"], data_format = "single-value")]
+#[derive(Clone)]
+pub struct UpgradeStartedEvent {
+    pub contract: Address,
+}
+
+/// Emitted when a two-phase upgrade completes (migration done). The data is the
+/// upgraded contract's own address.
+#[contractevent(topics = ["UPGRADE_COMPLETED"], data_format = "single-value")]
+#[derive(Clone)]
+pub struct UpgradeCompletedEvent {
+    pub contract: Address,
+}
 
 pub trait SmartAccountUpgradeable: SmartAccountUpgradeableAuth {
     fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
@@ -31,10 +46,10 @@ pub trait SmartAccountUpgradeableMigratable:
         Self::_require_auth_upgrade(e);
         ensure_no_pending_migration(e);
         enable_migration(e);
-        e.events().publish(
-            (Symbol::new(e, "UPGRADE_STARTED"),),
-            e.current_contract_address(),
-        );
+        UpgradeStartedEvent {
+            contract: e.current_contract_address(),
+        }
+        .publish(e);
         e.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 
@@ -43,10 +58,10 @@ pub trait SmartAccountUpgradeableMigratable:
         ensure_can_complete_migration(e);
         Self::_migrate(e, &migration_data);
         complete_migration(e);
-        e.events().publish(
-            (Symbol::new(e, "UPGRADE_COMPLETED"),),
-            e.current_contract_address(),
-        );
+        UpgradeCompletedEvent {
+            contract: e.current_contract_address(),
+        }
+        .publish(e);
     }
 }
 
@@ -101,10 +116,10 @@ macro_rules! impl_upgradeable_migratable {
                 Self::_require_auth_upgrade(e);
                 $crate::ensure_no_pending_migration(e);
                 $crate::enable_migration(e);
-                e.events().publish(
-                    (soroban_sdk::Symbol::new(e, "UPGRADE_STARTED"),),
-                    e.current_contract_address(),
-                );
+                $crate::UpgradeStartedEvent {
+                    contract: e.current_contract_address(),
+                }
+                .publish(e);
                 e.deployer().update_current_contract_wasm(new_wasm_hash);
             }
 
@@ -113,10 +128,10 @@ macro_rules! impl_upgradeable_migratable {
                 $crate::ensure_can_complete_migration(e);
                 Self::_migrate(e, &migration_data);
                 $crate::complete_migration(e);
-                e.events().publish(
-                    (soroban_sdk::Symbol::new(e, "UPGRADE_COMPLETED"),),
-                    e.current_contract_address(),
-                );
+                $crate::UpgradeCompletedEvent {
+                    contract: e.current_contract_address(),
+                }
+                .publish(e);
             }
         }
     };


### PR DESCRIPTION
## What

Migrates every `env.events().publish(...)` call in the workspace to the modern **`#[contractevent]`** macro — the recommended event API since soroban-sdk 23 — and removes all seven crate-level `#![allow(deprecated)]` attributes added in the SDK-27 bump.

Stacked on #131.

Event ABIs are preserved (identical topics + data) for 16 of 21 events; a few events in contracts nothing currently consumes (`PluginAuthFailed`, the factory's `ContractDeployed`, and the plugin-policy-example events) reshape slightly to fit the macro's rules (a dynamic topic can't sit between two static ones; a field can't be both a topic and data) — inconsequential given those events are unused.

## Verification

- `cargo test --workspace` — all pass
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo build --release --target wasm32v1-none` — all contracts compile

