### PR TITLE
fix(ci): add explicit permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a workflow-level `permissions: contents: read` block to `.github/workflows/test.yml`
- The `test` job only checks out the repo and runs `cargo test` — no write access needed
- Matches the existing convention in `lint.yml`, which already sets the same workflow-level permissions
- Resolves CodeQL alert #1 (`actions/missing-workflow-permissions`)

## Test plan
- [x] YAML validated
- [ ] Confirm the `test` workflow still runs successfully on this PR